### PR TITLE
Refactor Pixi element wrappers to isolate animation transforms

### DIFF
--- a/src/browser/AnimateInHandler.ts
+++ b/src/browser/AnimateInHandler.ts
@@ -19,173 +19,92 @@ export class AnimateInHandler extends BaseCommandHandler {
     const node = rm?.getNode ? rm.getNode(id) : null;
     if (!node) return this.createErrorResult(`Element not found: ${id}`);
 
+    const elementNode: any = (node as any).__elementNode;
+    const animTarget: any = (node as any).__animLayer || node;
+
     const preset: string = p.preset || 'fade';
     const duration: number = p.duration ?? 800;
     const easing: keyof typeof Easings = p.easing || (preset === 'bounce' ? 'easeOutBounce' : preset === 'back' ? 'easeOutBack' : preset === 'elastic' ? 'easeOutElastic' : 'easeOutQuad');
 
-    let from: any = p.from || {};
-    let to: any = p.to || {};
     const useResource = !!(p.animId || p.animationId);
-    if (useResource) {
+    if (useResource && elementNode) {
       const spec = p.animId || p.animationId;
-      // 非阻塞播放资源动画时间轴（按 ShowImage 的实现对齐：相对/绝对、旋转中心、时长缩放等）
-      this.playTimeline(node, spec, context, { overrideDuration: p.duration }).catch(() => {});
+      try {
+        await elementNode.setEntryTimeline(spec, { duration: p.duration, resolver: (id: string) => this.loadAnimationData(id, context) });
+      } catch {}
       return this.createSuccessResult({ elementId: id, animId: spec, nonBlocking: true });
-    } else {
-      if (!p.from && !p.to) {
-        switch (preset) {
-          case 'fade': from = { alpha: 0 }; to = { alpha: 1 }; break;
-          case 'bounce': from = { y: node.y - 40, alpha: 0.8 }; to = { y: node.y, alpha: 1 }; break;
-          case 'scaleIn': from = { scale: 0.2, alpha: 0.8 }; to = { scale: 1, alpha: 1 }; break;
-          case 'moveIn': {
-            const dir = p.direction || 'up';
-            const offset = p.offset ?? 60;
-            if (dir === 'up') from = { y: node.y + offset, alpha: 0.8 }; else if (dir === 'down') from = { y: node.y - offset, alpha: 0.8 }; else if (dir === 'left') from = { x: node.x + offset, alpha: 0.8 }; else from = { x: node.x - offset, alpha: 0.8 };
-            to = { x: node.x, y: node.y, alpha: 1 };
-            break;
-          }
-          default: from = { alpha: 0 }; to = { alpha: 1 }; break;
-        }
-      }
-
-      // 非阻塞：启动入场动画后立即返回，不阻塞后续指令
-      // 若需要阻塞，请在流程中显式添加 WAIT 指令
-      this.animator.animate(node, from, to, duration, easing);
-      return this.createSuccessResult({ elementId: id, preset, duration, easing, nonBlocking: true });
     }
+
+    let from: any = p.from ? { ...p.from } : {};
+    let to: any = p.to ? { ...p.to } : {};
+
+    if (!p.from && !p.to) {
+      switch (preset) {
+        case 'fade':
+          from = { alpha: 0 };
+          to = { alpha: 1 };
+          break;
+        case 'bounce':
+          from = { y: -40, alpha: 0.8 };
+          to = { y: 0, alpha: 1 };
+          break;
+        case 'scaleIn':
+          from = { scale: 0.2, alpha: 0.8 };
+          to = { scale: 1, alpha: 1 };
+          break;
+        case 'moveIn': {
+          const dir = p.direction || 'up';
+          const offset = p.offset ?? 60;
+          if (dir === 'up') from = { y: offset, alpha: 0.8 };
+          else if (dir === 'down') from = { y: -offset, alpha: 0.8 };
+          else if (dir === 'left') from = { x: offset, alpha: 0.8 };
+          else from = { x: -offset, alpha: 0.8 };
+          to = { x: 0, y: 0, alpha: 1 };
+          break;
+        }
+        default:
+          from = { alpha: 0 };
+          to = { alpha: 1 };
+          break;
+      }
+    }
+
+    try { elementNode?.resetAnimation?.(); } catch {}
+    this.animator.animate(animTarget, from, to, duration, easing);
+    return this.createSuccessResult({ elementId: id, preset, duration, easing, nonBlocking: true });
   }
 
-  private async playTimeline(node: any, specIdOrUrl: string, context: CommandContext, options?: { startFromCurrent?: boolean; overrideDuration?: number }): Promise<void> {
+  private async loadAnimationData(specIdOrUrl: string, context: CommandContext): Promise<any | null> {
     try {
       const url = await this.resolveAnimationUrl(specIdOrUrl, context);
-      if (!url || typeof (globalThis as any).fetch !== 'function') return; // Node 环境跳过
-      const startToken = ((node as any).__animToken || 0);
-      const tryFetch = async (u: string): Promise<any | null> => { try { const r = await fetch(u, { cache: 'force-cache' as any }); if (r.ok) return await r.json(); } catch {} return null; };
-      let data: any = ANIM_JSON_CACHE.get(url);
-      if (!data) { data = await tryFetch(url); if (data) ANIM_JSON_CACHE.set(url, data); }
+      if (!url || typeof (globalThis as any).fetch !== 'function') return null;
+      if (ANIM_JSON_CACHE.has(url)) return ANIM_JSON_CACHE.get(url);
+      const tryFetch = async (u: string) => {
+        try {
+          const resp = await fetch(u, { cache: 'force-cache' as any });
+          if (resp.ok) {
+            const data = await resp.json();
+            ANIM_JSON_CACHE.set(url, data);
+            return data;
+          }
+        } catch {}
+        return null;
+      };
+      let data = await tryFetch(url);
       if (!data) {
         try {
           const g: any = (typeof window !== 'undefined' ? (window as any) : (globalThis as any));
           const base: string = g?.__ASSET_BASE__ || g?.__PROJECT_BASE__ || '';
           if (base && typeof url === 'string' && url.startsWith(base)) {
             const rel = url.slice(base.length).replace(/^\/+/, '');
-            if (rel.startsWith('animations/')) { data = await tryFetch('/' + rel); if (data) ANIM_JSON_CACHE.set(url, data); }
+            if (rel.startsWith('animations/')) data = await tryFetch('/' + rel);
           }
         } catch {}
       }
-      if (!data) return;
-
-      // Build timeline and optionally scale to declared duration (from options or JSON)
-      const parseMs = (v: any): number => {
-        if (v == null) return 0;
-        if (typeof v === 'number') return v;
-        const s = String(v).trim();
-        if (/^\d+(\.\d+)?s$/i.test(s)) return Math.round(parseFloat(s) * 1000);
-        if (/^\d+(\.\d+)?ms$/i.test(s)) return Math.round(parseFloat(s));
-        const n = Number(s);
-        return Number.isFinite(n) ? n : 0;
-      };
-      let timeline = (data.timeline || []).map((k: any) => ({ ...k, time: parseMs(k?.time) })).sort((a: any, b: any) => parseMs(a.time) - parseMs(b.time));
-      try {
-        const declaredRaw: any = (options && (options as any).overrideDuration) ?? (data as any).duration ?? (data as any).period ?? (data as any).cycle ?? ((data as any).seconds != null ? Number((data as any).seconds) * 1000 : undefined);
-        const declared = parseMs(declaredRaw);
-        const lastT = parseMs((timeline[timeline.length - 1]?.time) || 0);
-        const angleLastT = (() => { let t = 0; for (const k of timeline) { if (k && k.props && (k.props.angle != null || k.props.rotation != null)) t = parseMs(k.time || 0); } return t; })();
-        let scale: number | null = null;
-        if (declared > 0) {
-          if (angleLastT > 0 && Math.abs(angleLastT - declared) > 1) scale = declared / angleLastT;
-          else if (lastT > 0 && Math.abs(lastT - declared) > 1) scale = declared / lastT;
-        }
-        if (scale && isFinite(scale) && scale > 0) {
-          timeline = timeline.map((k: any) => ({ ...k, time: Math.max(0, Math.round(parseMs(k.time || 0) * scale!)) }));
-        }
-      } catch {}
-
-      // 若动画未声明 relative，则在元素显式设定了大小时默认按相对模式处理
-      const sizeLocked = !!(node as any).__sizeLocked;
-      const relative = (data.relative != null) ? !!data.relative : sizeLocked;
-      const origin = data.origin;
-      // Do not mutate anchor during playback to avoid coordinate drift
-      if (timeline.length === 0) return;
-
-      // If rotation/angle animation exists, rotate around visual center without shifting position
-      try {
-        const usesRotation = timeline.some((k: any) => k && k.props && (k.props.angle != null || k.props.rotation != null));
-        if (usesRotation && !(node as any).__centerAnchored && (node as any).anchor && (typeof (node as any).anchor.set === 'function')) {
-          const ax = Number((node as any).anchor?.x ?? 0);
-          const ay = Number((node as any).anchor?.y ?? 0);
-          const w = Number((node as any).width || 0);
-          const h = Number((node as any).height || 0);
-          if (!(w > 0 && h > 0)) return; // wait until size ready
-          const posX = Number((node as any).x || 0);
-          const posY = Number((node as any).y || 0);
-          const centerX = posX + (0.5 - ax) * w;
-          const centerY = posY + (0.5 - ay) * h;
-          (node as any).anchor.set(0.5, 0.5);
-          (node as any).x = centerX; (node as any).y = centerY;
-          (node as any).__centerAnchored = true;
-        }
-      } catch {}
-
-      const toAbs = (props: any) => this.toAnimatorProps(props);
-      // baseline snapshots
-      const snapshotState = () => ({
-        x: (node as any).x || 0,
-        y: (node as any).y || 0,
-        alpha: (node as any).alpha ?? 1,
-        scaleX: (node as any).scale?.x ?? 1,
-        scaleY: (node as any).scale?.y ?? 1,
-        angle: (node as any).angle != null ? (node as any).angle : (((node as any).rotation ?? 0) * 180 / Math.PI)
-      });
-      const loopAnchor = snapshotState();
-      const lockedAnchor = snapshotState();
-      const resolveWithBase = (props: any, _posBase: { x:number; y:number }, _scaleBase: { scaleX:number; scaleY:number }) => {
-        const out = { ...props };
-        if (out.scale != null && (out.scaleX == null && out.scaleY == null)) {
-          const s = out.scale; if (typeof s === 'number') { out.scaleX = s; out.scaleY = s; } else if (s && typeof s === 'object') { if (s.x != null) out.scaleX = s.x; if (s.y != null) out.scaleY = s.y; }
-        }
-        if (relative) {
-          if (out.x != null) out.x = (loopAnchor.x ?? 0) + out.x;
-          if (out.y != null) out.y = (loopAnchor.y ?? 0) + out.y;
-          if (out.scaleX != null) out.scaleX = (loopAnchor.scaleX ?? 1) * out.scaleX;
-          if (out.scaleY != null) out.scaleY = (loopAnchor.scaleY ?? 1) * out.scaleY;
-          if (out.angle != null) out.angle = (loopAnchor.angle ?? 0) + out.angle;
-          if (out.rotation != null) { const currentRot = ((loopAnchor.angle ?? 0) * Math.PI / 180); out.rotation = currentRot + out.rotation; }
-        } else if (sizeLocked) {
-          if (out.scaleX != null) out.scaleX = (lockedAnchor.scaleX ?? 1) * out.scaleX;
-          if (out.scaleY != null) out.scaleY = (lockedAnchor.scaleY ?? 1) * out.scaleY;
-        }
-        return out;
-      };
-
-      // apply first frame unless startFromCurrent
-      if (((node as any).__animToken || 0) !== startToken) return;
-      const first = timeline[0];
-      const startFromCurrent = !!(options && options.startFromCurrent);
-      if (!startFromCurrent) {
-        this.applyAnimatorProps(node, toAbs(resolveWithBase(first.props || {}, { x: loopAnchor.x, y: loopAnchor.y }, { scaleX: loopAnchor.scaleX, scaleY: loopAnchor.scaleY })));
-      }
-
-      const EPS = 1e-4;
-      const almostEq = (a: number | undefined, b: number | undefined) => (a == null || b == null) ? false : Math.abs(a - b) <= EPS;
-      for (let i = 0; i < timeline.length - 1; i++) {
-        const cur = timeline[i];
-        const nxt = timeline[i + 1];
-        if (((node as any).__animToken || 0) !== startToken) return;
-        const from = this.getAnimatorState(node);
-        const to = toAbs(resolveWithBase(nxt.props || {}, { x: from.x ?? 0, y: from.y ?? 0 }, { scaleX: loopAnchor.scaleX, scaleY: loopAnchor.scaleY }));
-        const duration = Math.max(0, (nxt.time || 0) - (cur.time || 0));
-        const easing = nxt.ease || 'easeOutQuad';
-        const hasAnimProp = (('alpha' in to) || ('x' in to) || ('y' in to) || ('rotation' in to) || ('angle' in to) || !!to.scale);
-        if (!hasAnimProp) continue;
-        const angleNoChange = ('angle' in to) ? almostEq((from as any).angle, (to as any).angle) : true;
-        const rotNoChange = ('rotation' in to) ? almostEq((from as any).rotation, (to as any).rotation) : true;
-        const noChange = (( !('alpha' in to) || almostEq(from.alpha, to.alpha)) && (!('x' in to) || almostEq(from.x, to.x)) && (!('y' in to) || almostEq(from.y, to.y)) && (!to.scale || (almostEq(from.scale?.x, to.scale?.x) && almostEq(from.scale?.y, to.scale?.y))) && angleNoChange && rotNoChange);
-        if (noChange) continue;
-        await this.animator.animate(node, from, to, duration, easing as any);
-        if (((node as any).__animToken || 0) !== startToken) return;
-      }
-    } catch {}
+      return data;
+    } catch {
+      return null;
+    }
   }
 
   private async resolveAnimationUrl(spec: string, context: CommandContext): Promise<string | null> {
@@ -197,12 +116,12 @@ export class AnimateInHandler extends BaseCommandHandler {
     try {
       const g: any = (typeof window !== 'undefined' ? (window as any) : (globalThis as any));
       const getVfsUrl = g?.__VFS_GET_URL__;
-      const norm = (p: string) => String(p || '').replace(/^\.\//,'').replace(/^\/+/, '');
+      const norm = (p: string) => String(p || '').replace(/^\.\//, '').replace(/^\/+/, '');
       const ensureJson = (p: string) => p.endsWith('.json') ? p : (p + '.json');
       const candidates: string[] = [];
       const name = norm(spec);
       if (/\//.test(name)) {
-        candidates.push(ensureJson(name.startsWith('animations/') ? name : `animations/${name.replace(/^.*?\//,'')}`));
+        candidates.push(ensureJson(name.startsWith('animations/') ? name : `animations/${name.replace(/^.*?\//, '')}`));
       } else {
         candidates.push(ensureJson(`animations/${name}`));
         candidates.push(ensureJson(`animations/基础效果/${name}`));
@@ -215,40 +134,5 @@ export class AnimateInHandler extends BaseCommandHandler {
       }
       return '/' + candidates[0];
     } catch { return spec; }
-  }
-
-  private toAnimatorProps(props: any): any {
-    const out: any = {};
-    if (props.alpha != null) out.alpha = props.alpha;
-    if (props.x != null) out.x = props.x;
-    if (props.y != null) out.y = props.y;
-    if (props.rotation != null) out.rotation = props.rotation; // radians
-    if (props.angle != null) out.angle = props.angle; // degrees
-    if (props.scaleX != null || props.scaleY != null) {
-      out.scale = { x: props.scaleX ?? 1, y: props.scaleY ?? 1 };
-    } else if (props.scale != null) {
-      if (typeof props.scale === 'number') out.scale = { x: props.scale, y: props.scale };
-      else if (typeof props.scale === 'object') out.scale = { x: props.scale.x ?? 1, y: props.scale.y ?? 1 };
-    }
-    return out;
-  }
-
-  private applyAnimatorProps(node: any, props: any) {
-    if (!props) return;
-    if (props.alpha != null) node.alpha = props.alpha;
-    if (props.x != null) node.x = props.x;
-    if (props.y != null) node.y = props.y;
-    if (props.scale && node.scale) { node.scale.x = props.scale.x ?? node.scale.x; node.scale.y = props.scale.y ?? node.scale.y; }
-  }
-
-  private getAnimatorState(node: any) {
-    const st: any = {};
-    if (node.alpha != null) st.alpha = node.alpha;
-    if (node.x != null) st.x = node.x;
-    if (node.y != null) st.y = node.y;
-    if (node.scale) st.scale = { x: node.scale.x ?? 1, y: node.scale.y ?? 1 };
-    try { if ((node as any).angle != null) (st as any).angle = (node as any).angle; } catch {}
-    try { if ((node as any).rotation != null) (st as any).rotation = (node as any).rotation; } catch {}
-    return st;
   }
 }

--- a/src/browser/AnimateLoopHandler.ts
+++ b/src/browser/AnimateLoopHandler.ts
@@ -2,7 +2,6 @@ import { CommandType, GameCommand, CommandContext, CommandResult } from '../type
 import { BaseCommandHandler } from '../core/CommandExecutor';
 import { Animator } from './Animator';
 
-// Cache for animation JSON
 const ANIM_JSON_CACHE: Map<string, any> = new Map();
 
 export class AnimateLoopHandler extends BaseCommandHandler {
@@ -16,194 +15,110 @@ export class AnimateLoopHandler extends BaseCommandHandler {
     const rm: any = context.renderManager as any;
     const node = rm?.getNode ? rm.getNode(id) : null;
     if (!node) return this.createErrorResult(`Element not found: ${id}`);
-    // stop previous custom loop if any
+
+    const elementNode: any = (node as any).__elementNode;
+    const animTarget: any = (node as any).__animLayer || node;
+
     try { if ((node as any).__loopCancel) { (node as any).__loopCancel(); (node as any).__loopCancel = null; } } catch {}
+
     const animId: string | undefined = p.animId || p.animationId;
-    if (animId) {
-      // resource-based timeline looping (aligned to ShowImage implementation)
-      const runLoop = async () => {
-        let stopped = false;
-        const cancel = () => { stopped = true; };
-        (node as any).__loopCancel = cancel; (node as any).__loopAnimId = animId;
-        while (!stopped) {
-          try {
-            await playOnceTimeline(node, animId, context, this.animator, { startFromCurrent: true, overrideDuration: p.duration ?? p.period ?? p.cycle ?? (p.seconds != null ? Number(p.seconds) * 1000 : undefined) });
-            // after each cycle, continue unless cancelled/destroyed
-            try { if (!(node as any) || (node as any).destroyed) break; } catch { break; }
-          } catch {}
-        }
-      };
-      runLoop();
-      // 拖拽时暂停循环动画，释放时恢复
+    const durationOverride = p.duration ?? p.period ?? p.cycle ?? (p.seconds != null ? Number(p.seconds) * 1000 : undefined);
+
+    if (animId && elementNode) {
+      try {
+        await elementNode.setLoopTimeline(animId, { duration: durationOverride, resolver: (id: string) => this.loadAnimationData(id, context) });
+      } catch {}
+      (node as any).__loopAnimId = animId;
+      (node as any).__loopCancel = () => { try { elementNode.clearLoopTimeline(); } catch {} };
+
       if (!(node as any).__loopPauseHandlers && (node as any).on) {
-        const onDown = () => {
-          if (typeof (node as any).__animToken !== 'number') (node as any).__animToken = 0;
-          (node as any).__animToken++;
-          if ((node as any).__loopCancel) { try { (node as any).__loopCancel(); } catch {} (node as any).__loopCancel = null; }
+        const onDown = () => { try { elementNode.clearLoopTimeline(); } catch {} };
+        const onUp = () => {
+          const aid = (node as any).__loopAnimId;
+          if (aid) {
+            try { elementNode.setLoopTimeline(aid, { duration: durationOverride, resolver: (id: string) => this.loadAnimationData(id, context) }); } catch {}
+          }
         };
-        const onUp = () => { if (!(node as any).__loopCancel && (node as any).__loopAnimId) {
-          const aid = (node as any).__loopAnimId; const rp = async () => { let stopped=false; (node as any).__loopCancel = ()=>{stopped=true;}; while(!stopped){ await playOnceTimeline(node, aid, context, this.animator, { startFromCurrent: true, overrideDuration: p.duration ?? p.period ?? p.cycle ?? (p.seconds != null ? Number(p.seconds) * 1000 : undefined) }); if ((node as any).destroyed) break; } }; rp(); } };
         (node as any).on('pointerdown', onDown);
         (node as any).on('pointerup', onUp);
         (node as any).on('pointerupoutside', onUp);
         (node as any).__loopPauseHandlers = { onDown, onUp };
       }
+
       return this.createSuccessResult({ elementId: id, loopType: 'resource', animId });
     }
+
     const loopType: string = p.loopType || 'hoverY';
+    try { elementNode?.clearLoopTimeline?.(); } catch {}
+    this.animator.stop(animTarget);
+
     if (loopType === 'hoverY') {
-      this.animator.loopHoverY(node, p.amplitude ?? 6, p.duration ?? 1500);
+      this.animator.loopHoverY(animTarget, p.amplitude ?? 6, p.duration ?? 1500);
     } else if (loopType === 'pulse') {
-      this.animator.loopPulseScale(node, p.minScale ?? 0.95, p.maxScale ?? 1.05, p.duration ?? 1200);
+      this.animator.loopPulseScale(animTarget, p.minScale ?? 0.95, p.maxScale ?? 1.05, p.duration ?? 1200);
     }
     return this.createSuccessResult({ elementId: id, loopType });
   }
-}
 
-// Helpers aligned with ShowImage implementation
-async function resolveAnimationUrl(spec: string, context: CommandContext): Promise<string | null> {
-  if (!spec) return null;
-  const rm: any = (context as any).resourceManager;
-  const res = rm?.getResource ? rm.getResource(spec) : null;
-  if (res?.url) return res.url;
-  if (typeof spec !== 'string') return null;
-  try {
-    const g: any = (typeof window !== 'undefined' ? (window as any) : (globalThis as any));
-    const getVfsUrl = g?.__VFS_GET_URL__;
-    const norm = (p: string) => String(p || '').replace(/^\.\//,'').replace(/^\/+/, '');
-    const ensureJson = (p: string) => p.endsWith('.json') ? p : (p + '.json');
-    const candidates: string[] = [];
-    const name = norm(spec);
-    if (/\//.test(name)) {
-      candidates.push(ensureJson(name.startsWith('animations/') ? name : `animations/${name.replace(/^.*?\//,'')}`));
-    } else {
-      candidates.push(ensureJson(`animations/${name}`));
-      candidates.push(ensureJson(`animations/基础效果/${name}`));
+  private async loadAnimationData(specIdOrUrl: string, context: CommandContext): Promise<any | null> {
+    try {
+      const url = await this.resolveAnimationUrl(specIdOrUrl, context);
+      if (!url || typeof (globalThis as any).fetch !== 'function') return null;
+      if (ANIM_JSON_CACHE.has(url)) return ANIM_JSON_CACHE.get(url);
+      const tryFetch = async (u: string) => {
+        try {
+          const resp = await fetch(u, { cache: 'force-cache' as any });
+          if (resp.ok) {
+            const data = await resp.json();
+            ANIM_JSON_CACHE.set(url, data);
+            return data;
+          }
+        } catch {}
+        return null;
+      };
+      let data = await tryFetch(url);
+      if (!data) {
+        try {
+          const g: any = (typeof window !== 'undefined' ? (window as any) : (globalThis as any));
+          const base: string = g?.__ASSET_BASE__ || g?.__PROJECT_BASE__ || '';
+          if (base && typeof url === 'string' && url.startsWith(base)) {
+            const rel = url.slice(base.length).replace(/^\/+/, '');
+            if (rel.startsWith('animations/')) data = await tryFetch('/' + rel);
+          }
+        } catch {}
+      }
+      return data;
+    } catch {
+      return null;
     }
-    for (const rel0 of candidates) {
-      const rel = norm(rel0);
-      if (typeof getVfsUrl === 'function') { const u = await getVfsUrl(rel); if (u) return u; }
-      const base: string = g?.__ASSET_BASE__ || g?.__PROJECT_BASE__ || '';
-      if (base) return base.endsWith('/') ? (base + rel) : (base + '/' + rel);
-    }
-    return '/' + candidates[0];
-  } catch { return spec; }
-}
-
-function toAnimatorProps(props: any): any {
-  const out: any = {};
-  if (props.alpha != null) out.alpha = props.alpha;
-  if (props.x != null) out.x = props.x;
-  if (props.y != null) out.y = props.y;
-  if (props.rotation != null) out.rotation = props.rotation;
-  if (props.angle != null) out.angle = props.angle;
-  if (props.scaleX != null || props.scaleY != null) {
-    out.scale = { x: props.scaleX ?? 1, y: props.scaleY ?? 1 };
-  } else if (props.scale != null) {
-    if (typeof props.scale === 'number') out.scale = { x: props.scale, y: props.scale };
-    else if (typeof props.scale === 'object') out.scale = { x: props.scale.x ?? 1, y: props.scale.y ?? 1 };
   }
-  return out;
-}
 
-function applyAnimatorProps(node: any, props: any) {
-  if (!props) return;
-  if (props.alpha != null) node.alpha = props.alpha;
-  if (props.x != null) node.x = props.x;
-  if (props.y != null) node.y = props.y;
-  if (props.scale && node.scale) { node.scale.x = props.scale.x ?? node.scale.x; node.scale.y = props.scale.y ?? node.scale.y; }
-}
-
-function getAnimatorState(node: any) {
-  const st: any = {};
-  if (node.alpha != null) st.alpha = node.alpha;
-  if (node.x != null) st.x = node.x;
-  if (node.y != null) st.y = node.y;
-  if (node.scale) st.scale = { x: node.scale.x ?? 1, y: node.scale.y ?? 1 };
-  try { if ((node as any).angle != null) (st as any).angle = (node as any).angle; } catch {}
-  try { if ((node as any).rotation != null) (st as any).rotation = (node as any).rotation; } catch {}
-  return st;
-}
-
-async function playOnceTimeline(node: any, specIdOrUrl: string, context: CommandContext, animator: Animator, options?: { startFromCurrent?: boolean; overrideDuration?: number }) {
-  const url = await resolveAnimationUrl(specIdOrUrl, context);
-  if (!url || typeof (globalThis as any).fetch !== 'function') return;
-  const startToken = ((node as any).__animToken || 0);
-  const tryFetch = async (u: string): Promise<any | null> => { try { const r = await fetch(u, { cache: 'force-cache' as any }); if (r.ok) return await r.json(); } catch {} return null; };
-  let data: any = ANIM_JSON_CACHE.get(url);
-  if (!data) { data = await tryFetch(url); if (data) ANIM_JSON_CACHE.set(url, data); }
-  if (!data) {
+  private async resolveAnimationUrl(spec: string, context: CommandContext): Promise<string | null> {
+    if (!spec) return null;
+    const rm: any = (context as any).resourceManager;
+    const res = rm?.getResource ? rm.getResource(spec) : null;
+    if (res?.url) return res.url;
+    if (typeof spec !== 'string') return null;
     try {
       const g: any = (typeof window !== 'undefined' ? (window as any) : (globalThis as any));
-      const base: string = g?.__ASSET_BASE__ || g?.__PROJECT_BASE__ || '';
-      if (base && typeof url === 'string' && url.startsWith(base)) {
-        const rel = url.slice(base.length).replace(/^\/+/, '');
-        if (rel.startsWith('animations/')) { data = await tryFetch('/' + rel); if (data) ANIM_JSON_CACHE.set(url, data); }
+      const getVfsUrl = g?.__VFS_GET_URL__;
+      const norm = (p: string) => String(p || '').replace(/^\.\//, '').replace(/^\/+/, '');
+      const ensureJson = (p: string) => p.endsWith('.json') ? p : (p + '.json');
+      const candidates: string[] = [];
+      const name = norm(spec);
+      if (/\//.test(name)) {
+        candidates.push(ensureJson(name.startsWith('animations/') ? name : `animations/${name.replace(/^.*?\//, '')}`));
+      } else {
+        candidates.push(ensureJson(`animations/${name}`));
+        candidates.push(ensureJson(`animations/基础效果/${name}`));
       }
-    } catch {}
-  }
-  if (!data) return;
-
-  const parseMs = (v: any): number => { if (v == null) return 0; if (typeof v === 'number') return v; const s = String(v).trim(); if (/^\d+(\.\d+)?s$/i.test(s)) return Math.round(parseFloat(s) * 1000); if (/^\d+(\.\d+)?ms$/i.test(s)) return Math.round(parseFloat(s)); const n = Number(s); return Number.isFinite(n) ? n : 0; };
-  let timeline = (data.timeline || []).map((k: any) => ({ ...k, time: parseMs(k?.time) })).sort((a: any, b: any) => parseMs(a.time) - parseMs(b.time));
-  try {
-    const declaredRaw: any = (options && (options as any).overrideDuration) ?? (data as any).duration ?? (data as any).period ?? (data as any).cycle ?? ((data as any).seconds != null ? Number((data as any).seconds) * 1000 : undefined);
-    const declared = parseMs(declaredRaw);
-    const lastT = parseMs((timeline[timeline.length - 1]?.time) || 0);
-    const angleLastT = (() => { let t = 0; for (const k of timeline) { if (k && k.props && (k.props.angle != null || k.props.rotation != null)) t = parseMs(k.time || 0); } return t; })();
-    let scale: number | null = null;
-    if (declared > 0) {
-      if (angleLastT > 0 && Math.abs(angleLastT - declared) > 1) scale = declared / angleLastT;
-      else if (lastT > 0 && Math.abs(lastT - declared) > 1) scale = declared / lastT;
-    }
-    if (scale && isFinite(scale) && scale > 0) timeline = timeline.map((k: any) => ({ ...k, time: Math.max(0, Math.round(parseMs(k.time || 0) * scale!)) }));
-  } catch {}
-
-  const sizeLocked = !!(node as any).__sizeLocked;
-  const relative = (data.relative != null) ? !!data.relative : sizeLocked;
-  if (timeline.length === 0) return;
-
-  try {
-    const usesRotation = timeline.some((k: any) => k && k.props && (k.props.angle != null || k.props.rotation != null));
-    if (usesRotation && !(node as any).__centerAnchored && (node as any).anchor && (typeof (node as any).anchor.set === 'function')) {
-      const ax = Number((node as any).anchor?.x ?? 0); const ay = Number((node as any).anchor?.y ?? 0);
-      const w = Number((node as any).width || 0); const h = Number((node as any).height || 0);
-      if (!(w > 0 && h > 0)) return;
-      const posX = Number((node as any).x || 0); const posY = Number((node as any).y || 0);
-      const centerX = posX + (0.5 - ax) * w; const centerY = posY + (0.5 - ay) * h;
-      (node as any).anchor.set(0.5, 0.5); (node as any).x = centerX; (node as any).y = centerY; (node as any).__centerAnchored = true;
-    }
-  } catch {}
-
-  const loopAnchor = { x: (node as any).x || 0, y: (node as any).y || 0, alpha: (node as any).alpha ?? 1, scaleX: (node as any).scale?.x ?? 1, scaleY: (node as any).scale?.y ?? 1, angle: (node as any).angle != null ? (node as any).angle : (((node as any).rotation ?? 0) * 180 / Math.PI) };
-  const lockedAnchor = { ...loopAnchor };
-  const toAbs = (props: any) => toAnimatorProps(props);
-  const resolveWithBase = (props: any) => {
-    const out = { ...props } as any;
-    if (out.scale != null && (out.scaleX == null && out.scaleY == null)) { const s = out.scale; if (typeof s === 'number') { out.scaleX = s; out.scaleY = s; } else if (s && typeof s === 'object') { if (s.x != null) out.scaleX = s.x; if (s.y != null) out.scaleY = s.y; } }
-    if (relative) {
-      if (out.x != null) out.x = (loopAnchor.x ?? 0) + out.x;
-      if (out.y != null) out.y = (loopAnchor.y ?? 0) + out.y;
-      if (out.scaleX != null) out.scaleX = (loopAnchor.scaleX ?? 1) * out.scaleX;
-      if (out.scaleY != null) out.scaleY = (loopAnchor.scaleY ?? 1) * out.scaleY;
-      if (out.angle != null) out.angle = (loopAnchor.angle ?? 0) + out.angle;
-      if (out.rotation != null) { const currentRot = ((loopAnchor.angle ?? 0) * Math.PI / 180); out.rotation = currentRot + out.rotation; }
-    } else if (sizeLocked) {
-      if (out.scaleX != null) out.scaleX = (lockedAnchor.scaleX ?? 1) * out.scaleX;
-      if (out.scaleY != null) out.scaleY = (lockedAnchor.scaleY ?? 1) * out.scaleY;
-    }
-    return out;
-  };
-  if (((node as any).__animToken || 0) !== startToken) return;
-  const first = timeline[0];
-  applyAnimatorProps(node, toAbs(resolveWithBase(first.props || {})));
-  for (let i=0;i<timeline.length-1;i++) {
-    const cur = timeline[i]; const nxt = timeline[i+1];
-    if (((node as any).__animToken || 0) !== startToken) return;
-    const from = getAnimatorState(node);
-    const to = toAbs(resolveWithBase(nxt.props || {}));
-    const dur = Math.max(0, (nxt.time||0)-(cur.time||0));
-    await animator.animate(node, from, to, dur, (nxt.ease||'easeOutQuad') as any);
-    if (((node as any).__animToken || 0) !== startToken) return;
+      for (const rel0 of candidates) {
+        const rel = norm(rel0);
+        if (typeof getVfsUrl === 'function') { const u = await getVfsUrl(rel); if (u) return u; }
+        const base: string = g?.__ASSET_BASE__ || g?.__PROJECT_BASE__ || '';
+        if (base) return base.endsWith('/') ? (base + rel) : (base + '/' + rel);
+      }
+      return '/' + candidates[0];
+    } catch { return spec; }
   }
 }

--- a/src/browser/PixiRendererManager.ts
+++ b/src/browser/PixiRendererManager.ts
@@ -1,17 +1,19 @@
 // Minimal Pixi-based IRendererManager implementation for browser
 import { IRendererManager, ElementConfig, RenderElement } from '../types';
+import { RenderElementNode } from './rendering/RenderElementNode';
 
 declare const PIXI: any;
 
 export class PixiRendererManager implements IRendererManager {
   private app: any;
-  private elements = new Map<string, any>();
+  private elements = new Map<string, RenderElementNode>();
   private dropZones = new Map<string, { x: number; y: number; w: number; h: number; accept?: string[] }>();
   private pixi: any;
   public animationAdapter: any;
   // Exclusive interaction guard: when set, only this element remains interactive
   private exclusiveInteractiveId: string | null = null;
   private savedInteraction = new Map<string, { mode?: any; interactive?: boolean; interactiveChildren?: boolean; hitArea?: any }>();
+  private tickerFn: ((delta: number) => void) | null = null;
 
   constructor(app: any, pixiRef?: any) {
     this.app = app;
@@ -39,28 +41,39 @@ export class PixiRendererManager implements IRendererManager {
         return Promise.resolve(id);
       }
     };
+
+    if (this.app?.ticker) {
+      this.tickerFn = () => {
+        const deltaMS = this.app?.ticker?.deltaMS ?? 16.67;
+        for (const node of this.elements.values()) {
+          try { node.update(deltaMS); } catch {}
+        }
+      };
+      this.app.ticker.add(this.tickerFn);
+    }
   }
 
+
   createElement(config: ElementConfig): RenderElement {
-    let node: any;
     const P = this.pixi;
-    if (config.type === 'image') {
+    const type = config.type || 'image';
+    const style: any = config.style || {};
+    let visual: any;
+
+    if (type === 'image') {
       const texture = P.Texture.from(config.src || '');
       const sprite = new P.Sprite(texture);
       try { (sprite as any).resourceId = (config as any).resourceId || (sprite as any).resourceId; } catch {}
-      node = sprite;
-    } else if (config.type === 'nine-slice') {
+      visual = sprite;
+    } else if (type === 'nine-slice') {
       const texture = P.Texture.from(config.src || '');
       const s = (config as any).slice || { left: 12, top: 12, right: 12, bottom: 12 };
-      const plane = new P.NineSlicePlane(texture, Number(s.left||12), Number(s.top||12), Number(s.right||12), Number(s.bottom||12));
-      node = plane;
-    } else if (config.type === 'text') {
+      visual = new P.NineSlicePlane(texture, Number(s.left || 12), Number(s.top || 12), Number(s.right || 12), Number(s.bottom || 12));
+    } else if (type === 'text') {
       const rawStyle: any = config.style || {};
-      // Map style fields
       const fill = (rawStyle.fill || rawStyle.color) || '#ffffff';
       const fontSize = rawStyle.fontSize ? parseInt(String(rawStyle.fontSize)) : 16;
       const lineHeight = rawStyle.lineHeight ? parseInt(String(rawStyle.lineHeight)) : Math.round(fontSize * 1.3);
-      // compute wrap width: prefer explicit maxWidth, else canvas width minus padding
       const rendererWidth = this.app?.renderer?.width || 800;
       let wrapWidth: number | undefined;
       if (rawStyle.maxWidth != null) {
@@ -69,7 +82,7 @@ export class PixiRendererManager implements IRendererManager {
       } else if (rawStyle.wordWrapWidth != null) {
         wrapWidth = Number(rawStyle.wordWrapWidth);
       } else {
-        wrapWidth = undefined; // do not force wrap width; keep by content/default
+        wrapWidth = undefined;
       }
       const safeColor = (v: any, fallback: any) => (typeof v === 'string' || typeof v === 'number') ? v : fallback;
       const textStyle: any = {
@@ -83,9 +96,7 @@ export class PixiRendererManager implements IRendererManager {
         dropShadow: rawStyle.dropShadow === true,
         fontWeight: rawStyle.fontWeight || rawStyle.bold === true ? 'bold' : (rawStyle.fontWeight || 'normal'),
       };
-      // For Pixi v6 compatibility, provide leading
       (textStyle as any).leading = Math.max(0, lineHeight - fontSize);
-      // only include stroke when provided
       const strokeVal = rawStyle.stroke || rawStyle.strokeColor;
       if (strokeVal != null && strokeVal !== 'none') {
         textStyle.stroke = safeColor(strokeVal, '#000000');
@@ -93,7 +104,6 @@ export class PixiRendererManager implements IRendererManager {
       } else {
         textStyle.strokeThickness = 0;
       }
-      // only include shadow color when enabled
       if (textStyle.dropShadow) {
         textStyle.dropShadowColor = safeColor(rawStyle.dropShadowColor, 0x000000);
         if (rawStyle.dropShadowBlur != null) textStyle.dropShadowBlur = parseInt(String(rawStyle.dropShadowBlur));
@@ -101,7 +111,7 @@ export class PixiRendererManager implements IRendererManager {
         if (rawStyle.dropShadowDistance != null) textStyle.dropShadowDistance = Number(rawStyle.dropShadowDistance);
       }
       const hasMarkup = (s: any) => {
-        try { const t = String(s || ''); return /<\/?(b|color|c|span|br)\b/i.test(t); } catch { return false; }
+        try { const t = String(s || ''); return /<\/?(b|color|c|span|br)/i.test(t); } catch { return false; }
       };
       const parseColorVal = (raw: string | undefined): any => {
         if (!raw) return undefined;
@@ -135,19 +145,18 @@ export class PixiRendererManager implements IRendererManager {
           if (!closing) {
             if (tag === 'b') stack.push({ bold: true });
             else if (tag === 'color' || tag === 'c') {
-              const m1 = attrs.match(/=\s*(['"]?)(#[0-9a-fA-F]{3,8}|0x[0-9a-fA-F]+|[a-zA-Z]+)\1/);
+              const m1 = attrs.match(/=\s*(['"]?)(#[0-9a-fA-F]{3,8}|0x[0-9a-fA-F]+|[a-zA-Z]+)/);
               const col = parseColorVal(m1 ? m1[2] : undefined);
               stack.push({ color: col });
             } else if (tag === 'span') {
               let col: any;
-              const m2 = attrs.match(/\bcolor\s*=\s*['"]([^'\"]+)['"]/i);
+              const m2 = attrs.match(/color\s*=\s*['"]([^'"]+)['"]/i);
               if (m2) col = parseColorVal(m2[1]);
-              const m3 = attrs.match(/style\s*=\s*['"][^'\"]*color\s*:\s*([^;'\"]+)/i);
+              const m3 = attrs.match(/style\s*=\s*['"][^'"]*color\s*:\s*([^;'"]+)/i);
               if (!col && m3) col = parseColorVal(m3[1]);
               stack.push({ color: col });
             }
           } else {
-            // pop until matching tag type or stack empty
             if (tag === 'b') {
               for (let i = stack.length - 1; i >= 0; i--) { if (stack[i].bold) { stack.splice(i, 1); break; } }
             } else {
@@ -157,17 +166,16 @@ export class PixiRendererManager implements IRendererManager {
           last = re.lastIndex;
         }
         if (last < src.length) pushText(src.slice(last));
-        // Split tokens by explicit newlines
         const expanded: Array<{ t: 'text'|'br'; text?: string; style?: any }> = [];
         tokens.forEach(tok => {
           if (tok.t === 'br') { expanded.push(tok); return; }
-          const parts = String(tok.text || '').split(/\n/);
+          const parts = String(tok.text || '').split(/
+/);
           for (let i = 0; i < parts.length; i++) {
             if (i > 0) expanded.push({ t: 'br' });
             if (parts[i]) expanded.push({ t: 'text', text: parts[i], style: tok.style });
           }
         });
-        // Layout lines without auto word-wrap (respect explicit breaks)
         let x = 0, y = 0, lineH = Math.ceil(baseStyle.lineHeight || baseStyle.fontSize || 16);
         const align = String(baseStyle.align || 'left');
         const lines: Array<Array<any>> = [[]];
@@ -180,11 +188,9 @@ export class PixiRendererManager implements IRendererManager {
           (t as any).__segment = true;
           lines[lines.length - 1].push(t);
         });
-        // measure and place
         y = 0;
         lines.forEach((arr) => {
           x = 0; lineH = 0;
-          // total line width for alignment
           let lineW = 0; arr.forEach((t: any) => { lineW += Math.ceil(t.width); lineH = Math.max(lineH, Math.ceil(t.height)); });
           let startX = 0;
           if (align === 'center' && wrapWidth != null) startX = Math.max(0, Math.round((wrapWidth - lineW) / 2));
@@ -197,92 +203,85 @@ export class PixiRendererManager implements IRendererManager {
       };
       const contentText = String((config as any).content || '');
       if (hasMarkup(contentText)) {
-        node = buildRichText(contentText, textStyle);
+        visual = buildRichText(contentText, textStyle);
       } else {
-        const text = new P.Text(contentText, textStyle);
-        node = text;
+        const textNode = new P.Text(contentText, textStyle);
+        (textNode as any).__rawText = contentText;
+        visual = textNode;
       }
     } else {
-      // fallback container
-      node = new P.Container();
+      visual = new P.Container();
     }
 
-    node.x = config.position?.x || 0;
-    node.y = config.position?.y || 0;
-    // size: only apply when valid finite numbers; ignore empty strings
-    if (config.size && node.width !== undefined && node.height !== undefined) {
-      const rw: any = (config.size as any).width;
-      const rh: any = (config.size as any).height;
-      const w = Number(rw);
-      const h = Number(rh);
-      if (Number.isFinite(w) && w > 0) node.width = Math.round(w);
-      if (Number.isFinite(h) && h > 0) node.height = Math.round(h);
+    const node = new RenderElementNode(P, type, visual, { id: config.id });
+    const wrapper = node.wrapper;
+
+    if ((config as any).resourceId) {
+      try { (wrapper as any).resourceId = (config as any).resourceId; } catch {}
+      try { if (visual) (visual as any).resourceId = (config as any).resourceId; } catch {}
     }
-    node.visible = config.visible !== false;
-    if (config.style?.zIndex != null) node.zIndex = config.style.zIndex;
-    // anchor support for sprites/planes
-    try {
-      if ((node as any).anchor) {
-        const ax = (config.style as any)?.anchorX; const ay = (config.style as any)?.anchorY;
-        if (ax != null || ay != null) (node as any).anchor.set(ax ?? (node as any).anchor.x ?? 0, ay ?? (node as any).anchor.y ?? 0);
-        if ((config.style as any)?.anchorCenter) (node as any).anchor.set(0.5);
-      }
-    } catch {}
-    // optional anchor centering for sprites
-    try {
-      if ((node as any).anchor && config.style && (config.style as any).anchorCenter) {
-        (node as any).anchor.set(0.5);
-      }
-    } catch {}
-    // Parent support: add to parent if provided
+
+    wrapper.visible = config.visible !== false;
+    if (style?.zIndex != null) wrapper.zIndex = Number(style.zIndex);
+
+    if (style?.anchorCenter) node.setAnchor(undefined, undefined, true);
+    else node.setAnchor(style?.anchorX, style?.anchorY, false);
+
+    const pos = config.position || { x: 0, y: 0 };
+    node.setBasePosition(pos.x ?? 0, pos.y ?? 0);
+
+    const scaleCfg: any = (config as any).scale ?? config.scale;
+    if (scaleCfg != null) {
+      if (typeof scaleCfg === 'number') node.setBaseScale({ x: scaleCfg, y: scaleCfg });
+      else node.setBaseScale(scaleCfg);
+    }
+
+    if (config.rotation != null) node.setBaseRotation(config.rotation);
+    node.setVisible(config.visible !== false);
+
+    if (config.size) {
+      node.setSize((config.size as any).width, (config.size as any).height);
+    }
+
     const parentNode = config.parentId ? this.elements.get(config.parentId) : null;
-    if (parentNode && parentNode.addChild) {
-      parentNode.addChild(node);
+    if (parentNode) {
+      node.attachTo(parentNode);
     } else {
-      this.app.stage.addChild(node);
+      this.app.stage.addChild(wrapper);
     }
-    // If explicit size provided, apply and mark as size-locked to help animations respect current size
-    try {
-      if (config.size && (config.size as any).width && (config.size as any).height && (node as any).width !== undefined) {
-        const w = Number((config.size as any).width);
-        const h = Number((config.size as any).height);
-        if (Number.isFinite(w) && w > 0) (node as any).width = Math.round(w);
-        if (Number.isFinite(h) && h > 0) (node as any).height = Math.round(h);
-        (node as any).__sizeLocked = true;
-        (node as any).__baseScale = { x: (node as any).scale?.x ?? 1, y: (node as any).scale?.y ?? 1 };
-      }
-    } catch {}
-    this.elements.set(config.id, node);
 
-    // If an exclusive interactive lock is active for another id,
-    // immediately disable interactivity for this newly created node
+    this.elements.set(config.id, node);
+    node.update(0);
+
     if (this.exclusiveInteractiveId && this.exclusiveInteractiveId !== config.id) {
       try {
         if (!this.savedInteraction.has(config.id)) {
           this.savedInteraction.set(config.id, {
-            mode: (node as any).eventMode,
-            interactive: (node as any).interactive,
-            interactiveChildren: (node as any).interactiveChildren,
-            hitArea: (node as any).hitArea
+            mode: (wrapper as any).eventMode,
+            interactive: (wrapper as any).interactive,
+            interactiveChildren: (wrapper as any).interactiveChildren,
+            hitArea: (wrapper as any).hitArea
           });
         }
-        if ('eventMode' in (node as any)) (node as any).eventMode = 'none';
-        if ('interactive' in (node as any)) (node as any).interactive = false;
-        if ('interactiveChildren' in (node as any)) (node as any).interactiveChildren = false;
-        if ('hitArea' in (node as any)) (node as any).hitArea = null;
+        if ('eventMode' in (wrapper as any)) (wrapper as any).eventMode = 'none';
+        if ('interactive' in (wrapper as any)) (wrapper as any).interactive = false;
+        if ('interactiveChildren' in (wrapper as any)) (wrapper as any).interactiveChildren = false;
+        if ('hitArea' in (wrapper as any)) (wrapper as any).hitArea = null;
       } catch {}
     }
 
+    const base = node.getBaseSnapshot();
+    const rendered = node.getRenderedTransform();
     const self = this;
     return {
       id: config.id,
       type: config.type,
-      position: config.position || { x: 0, y: 0 },
-      size: config.size || { width: node.width || 0, height: node.height || 0 },
-      rotation: node.rotation || 0,
-      scale: node.scale || { x: 1, y: 1 },
-      visible: node.visible,
-      interactive: !!node.interactive,
+      position: { x: base.x, y: base.y },
+      size: { width: rendered.width, height: rendered.height },
+      rotation: base.rotation,
+      scale: { x: base.scaleX, y: base.scaleY },
+      visible: base.visible,
+      interactive: !!(wrapper as any).interactive,
       update(updates: Partial<ElementConfig>): void {
         self.updateElement(config.id, updates);
       },
@@ -295,42 +294,49 @@ export class PixiRendererManager implements IRendererManager {
   updateElement(id: string, updates: Partial<ElementConfig>): void {
     const node = this.elements.get(id);
     if (!node) return;
-    // Apply anchor-related style first to avoid visual shift after position is set
-    if (updates.style && (node as any).anchor) {
+    const wrapper: any = node.wrapper;
+    const content: any = node.content;
+
+    if (updates.style) {
       const st: any = updates.style;
-      if (st.anchorCenter) (node as any).anchor.set(0.5);
-      const ax = st.anchorX; const ay = st.anchorY;
-      if (ax != null || ay != null) (node as any).anchor.set(ax ?? (node as any).anchor.x ?? 0, ay ?? (node as any).anchor.y ?? 0);
+      if (st.anchorCenter || st.anchorX != null || st.anchorY != null) {
+        node.setAnchor(st.anchorX, st.anchorY, !!st.anchorCenter);
+      }
+      if (st.zIndex != null) {
+        try { wrapper.zIndex = Number(st.zIndex); wrapper.parent?.sortChildren?.(); } catch {}
+      }
     }
-    if (updates.position) { node.x = (updates.position.x ?? node.x); node.y = (updates.position.y ?? node.y); }
-    if (updates.size && node.width !== undefined) {
-      const rw: any = (updates.size as any).width;
-      const rh: any = (updates.size as any).height;
-      const w = (rw != null) ? Number(rw) : undefined;
-      const h = (rh != null) ? Number(rh) : undefined;
-      let applied = false;
-      if (Number.isFinite(w as any) && (w as any) > 0) { node.width = Math.round(w as any); applied = true; }
-      if (Number.isFinite(h as any) && (h as any) > 0) { node.height = Math.round(h as any); applied = true; }
-      if (applied) { try { (node as any).__sizeLocked = true; (node as any).__baseScale = { x: (node as any).scale?.x ?? 1, y: (node as any).scale?.y ?? 1 }; } catch {} }
+
+    if (updates.position) {
+      node.setBasePosition(updates.position.x, updates.position.y);
     }
-    if (updates.visible != null) node.visible = updates.visible;
-    if (updates.rotation != null) node.rotation = updates.rotation;
-    if (updates.scale && node.scale) { node.scale.x = updates.scale.x ?? node.scale.x; node.scale.y = updates.scale.y ?? node.scale.y; }
-    if (updates.type === 'text' && (updates as any).content !== undefined) {
-      const content = (updates as any).content;
-      if ((node as any).__isRichText) {
+    if (updates.size) {
+      node.setSize((updates.size as any).width, (updates.size as any).height);
+    }
+    if (updates.visible != null) {
+      node.setVisible(!!updates.visible);
+    }
+    if (updates.rotation != null) {
+      node.setBaseRotation(updates.rotation);
+    }
+    if (updates.scale) {
+      node.setBaseScale(updates.scale);
+    }
+
+    if ((updates as any).content !== undefined && updates.type === 'text') {
+      const contentText = (updates as any).content;
+      if (content && (content as any).__isRichText) {
         try {
-          const base = (node as any).__richBaseStyle || {};
-          const wrapWidth = (node as any).__wrapWidth;
+          const base = (content as any).__richBaseStyle || {};
+          const wrapWidth = (content as any).__wrapWidth;
           const P = this.pixi;
-          // rebuild children
-          while (node.children?.length) { try { node.removeChild(node.children[node.children.length - 1]); } catch {} }
-          const builder = (contentText: string, baseStyle: any) => {
-            // reuse same simple builder as in createElement
-            const hasMarkup = (s: any) => { try { const t = String(s || ''); return /<\/?(b|color|c|span|br)\b/i.test(t); } catch { return false; } };
+          while (content.children?.length) { try { content.removeChild(content.children[content.children.length - 1]); } catch {} }
+          const builder = (textSrc: string, baseStyle: any) => {
+            const hasMarkup = (s: any) => { try { const t = String(s || ''); return /<\/?(b|color|c|span|br)/i.test(t); } catch { return false; } };
             const parseColorVal = (raw: string | undefined): any => {
-              if (!raw) return undefined; const s = String(raw).trim();
-              if (s.startsWith('#')) { const hex = s.length === 4 ? ('#' + s[1]+s[1]+s[2]+s[2]+s[3]+s[3]) : s; return parseInt('0x' + hex.slice(1)); }
+              if (!raw) return undefined;
+              const s = String(raw).trim();
+              if (s.startsWith('#')) { const hex = s.length === 4 ? ('#' + s[1] + s[1] + s[2] + s[2] + s[3] + s[3]) : s; return parseInt('0x' + hex.slice(1)); }
               if (/^0x/i.test(s)) { try { return parseInt(s); } catch { return s; } }
               return s;
             };
@@ -338,77 +344,112 @@ export class PixiRendererManager implements IRendererManager {
             const stack: Array<{ bold?: boolean; color?: any }> = [];
             const cur = () => ({ bold: stack.some(s => s.bold), color: (() => { for (let i = stack.length - 1; i >= 0; i--) { if (stack[i].color != null) return stack[i].color; } return undefined; })() });
             const pushText = (s: string) => { if (!s) return; tokens.push({ t: 'text', text: s, style: cur() }); };
-            const src = String(contentText || '');
-            const re = /<\/?(b|color|c|span|br)([^>]*)>/ig; let last = 0; let m: RegExpExecArray | null;
+            const src = String(textSrc || '');
+            const re = /<\/?(b|color|c|span|br)([^>]*)>/ig;
+            let last = 0; let m: RegExpExecArray | null;
             while ((m = re.exec(src))) {
               if (m.index > last) pushText(src.slice(last, m.index));
-              const closing = src[m.index + 1] === '/'; const tag = m[1].toLowerCase(); const attrs = m[2] || '';
+              const closing = src[m.index + 1] === '/';
+              const tag = m[1].toLowerCase();
+              const attrs = m[2] || '';
               if (tag === 'br' && !closing) { tokens.push({ t: 'br' }); last = re.lastIndex; continue; }
               if (!closing) {
                 if (tag === 'b') stack.push({ bold: true });
-                else if (tag === 'color' || tag === 'c') { const m1 = attrs.match(/=\s*(['"]?)(#[0-9a-fA-F]{3,8}|0x[0-9a-fA-F]+|[a-zA-Z]+)\1/); const col = parseColorVal(m1 ? m1[2] : undefined); stack.push({ color: col }); }
-                else if (tag === 'span') { let col: any; const m2 = attrs.match(/\bcolor\s*=\s*['"]([^'\"]+)['"]/i); if (m2) col = parseColorVal(m2[1]); const m3 = attrs.match(/style\s*=\s*['"][^'\"]*color\s*:\s*([^;'\"]+)/i); if (!col && m3) col = parseColorVal(m3[1]); stack.push({ color: col }); }
+                else if (tag === 'color' || tag === 'c') {
+                  const m1 = attrs.match(/=\s*(['"]?)(#[0-9a-fA-F]{3,8}|0x[0-9a-fA-F]+|[a-zA-Z]+)/);
+                  const col = parseColorVal(m1 ? m1[2] : undefined);
+                  stack.push({ color: col });
+                } else if (tag === 'span') {
+                  let col: any;
+                  const m2 = attrs.match(/color\s*=\s*['"]([^'"]+)['"]/i);
+                  if (m2) col = parseColorVal(m2[1]);
+                  const m3 = attrs.match(/style\s*=\s*['"][^'"]*color\s*:\s*([^;'"]+)/i);
+                  if (!col && m3) col = parseColorVal(m3[1]);
+                  stack.push({ color: col });
+                }
               } else {
-                if (tag === 'b') { for (let i = stack.length - 1; i >= 0; i--) { if (stack[i].bold) { stack.splice(i, 1); break; } } }
-                else { for (let i = stack.length - 1; i >= 0; i--) { if (stack[i].color != null) { stack.splice(i, 1); break; } } }
+                if (tag === 'b') {
+                  for (let i = stack.length - 1; i >= 0; i--) { if (stack[i].bold) { stack.splice(i, 1); break; } }
+                } else {
+                  for (let i = stack.length - 1; i >= 0; i--) { if (stack[i].color != null) { stack.splice(i, 1); break; } }
+                }
               }
               last = re.lastIndex;
             }
             if (last < src.length) pushText(src.slice(last));
             const expanded: Array<{ t: 'text'|'br'; text?: string; style?: any }> = [];
-            tokens.forEach(tok => { if (tok.t === 'br') { expanded.push(tok); return; } const parts = String(tok.text || '').split(/\n/); for (let i=0;i<parts.length;i++){ if(i>0) expanded.push({t:'br'}); if(parts[i]) expanded.push({t:'text', text: parts[i], style: tok.style}); } });
-            // lay out again
-            let x = 0, y = 0, lineH = Math.ceil(base.lineHeight || base.fontSize || 16);
-            const align = String(base.align || 'left');
+            tokens.forEach(tok => {
+              if (tok.t === 'br') { expanded.push(tok); return; }
+              const parts = String(tok.text || '').split(/
+/);
+              for (let i = 0; i < parts.length; i++) {
+                if (i > 0) expanded.push({ t: 'br' });
+                if (parts[i]) expanded.push({ t: 'text', text: parts[i], style: tok.style });
+              }
+            });
+            let x = 0, y = 0, lineH = Math.ceil(baseStyle.lineHeight || baseStyle.fontSize || 16);
+            const align = String(baseStyle.align || 'left');
             const lines: Array<Array<any>> = [[]];
-            expanded.forEach(tok => { if (tok.t==='br'){ lines.push([]); return;} const st = { ...base }; if (tok.style?.bold) st.fontWeight = 'bold'; if (tok.style?.color != null) st.fill = tok.style.color; const t = new P.Text(tok.text || '', st); (t as any).__segment = true; lines[lines.length-1].push(t); });
-            y = 0; lines.forEach((arr) => { x = 0; lineH = 0; let lineW = 0; arr.forEach((t:any)=>{ lineW += Math.ceil(t.width); lineH = Math.max(lineH, Math.ceil(t.height)); }); let startX = 0; if (align==='center' && wrapWidth != null) startX = Math.max(0, Math.round((wrapWidth - lineW)/2)); else if (align==='right' && wrapWidth != null) startX = Math.max(0, Math.round((wrapWidth - lineW))); x = startX; arr.forEach((t:any)=>{ t.x = x; t.y = y; node.addChild(t); x += Math.ceil(t.width); }); y += (lineH>0? lineH : (base.lineHeight || base.fontSize || 16)); });
+            expanded.forEach(tok => {
+              if (tok.t === 'br') { lines.push([]); return; }
+              const st = { ...baseStyle };
+              if (tok.style?.bold) st.fontWeight = 'bold';
+              if (tok.style?.color != null) st.fill = tok.style.color;
+              const t = new P.Text(tok.text || '', st);
+              (t as any).__segment = true;
+              lines[lines.length - 1].push(t);
+            });
+            y = 0;
+            lines.forEach((arr) => {
+              x = 0; lineH = 0;
+              let lineW = 0; arr.forEach((t: any) => { lineW += Math.ceil(t.width); lineH = Math.max(lineH, Math.ceil(t.height)); });
+              let startX = 0;
+              if (align === 'center' && wrapWidth != null) startX = Math.max(0, Math.round((wrapWidth - lineW) / 2));
+              else if (align === 'right' && wrapWidth != null) startX = Math.max(0, Math.round((wrapWidth - lineW)));
+              x = startX;
+              arr.forEach((t: any) => { t.x = x; t.y = y; content.addChild(t); x += Math.ceil(t.width); });
+              y += (lineH > 0 ? lineH : (baseStyle.lineHeight || baseStyle.fontSize || 16));
+            });
           };
-          (node as any).__rawText = content;
-          builder(String(content ?? ''), base);
+          (content as any).__rawText = contentText;
+          builder(String(contentText ?? ''), base);
         } catch {}
-      } else {
-        node.text = content;
+      } else if (content && typeof content.text === 'string') {
+        content.text = contentText;
       }
     }
-    if (updates.style && node.style) {
+
+    if (updates.style && content?.style) {
       const st: any = updates.style;
-      if (st.fill || st.color) node.style.fill = (st.fill || st.color);
-      if (st.fontSize) node.style.fontSize = parseInt(String(st.fontSize));
+      if (st.fill || st.color) content.style.fill = st.fill || st.color;
+      if (st.fontSize) content.style.fontSize = parseInt(String(st.fontSize));
       if (st.maxWidth || st.padding) {
         const rendererWidth = this.app?.renderer?.width || 800;
         const pad = st.padding ? parseInt(String(st.padding)) : 40;
         const wrapWidth = st.maxWidth ? (String(st.maxWidth).endsWith('px') ? parseInt(String(st.maxWidth)) : Number(st.maxWidth)) : Math.max(100, rendererWidth - pad * 2);
-        node.style.wordWrap = true;
-        node.style.wordWrapWidth = wrapWidth;
+        content.style.wordWrap = true;
+        content.style.wordWrapWidth = wrapWidth;
       }
-      if (st.textAlign || st.align) node.style.align = st.textAlign || st.align;
-      if (st.lineHeight) node.style.lineHeight = parseInt(String(st.lineHeight));
-      if (st.fontFamily || st.font) node.style.fontFamily = st.fontFamily || st.font;
+      if (st.textAlign || st.align) content.style.align = st.textAlign || st.align;
+      if (st.lineHeight) content.style.lineHeight = parseInt(String(st.lineHeight));
+      if (st.fontFamily || st.font) content.style.fontFamily = st.fontFamily || st.font;
       if (st.stroke || st.strokeColor || st.strokeThickness != null) {
-        if (st.stroke || st.strokeColor) node.style.stroke = st.stroke || st.strokeColor;
-        if (st.strokeThickness != null) node.style.strokeThickness = parseInt(String(st.strokeThickness));
+        if (st.stroke || st.strokeColor) content.style.stroke = st.stroke || st.strokeColor;
+        if (st.strokeThickness != null) content.style.strokeThickness = parseInt(String(st.strokeThickness));
       }
-      if (st.dropShadow != null) node.style.dropShadow = !!st.dropShadow;
-      if (st.dropShadowColor) node.style.dropShadowColor = st.dropShadowColor;
-      if (st.dropShadowBlur != null) node.style.dropShadowBlur = parseInt(String(st.dropShadowBlur));
-      if (st.dropShadowAngle != null) node.style.dropShadowAngle = Number(st.dropShadowAngle);
-      if (st.dropShadowDistance != null) node.style.dropShadowDistance = Number(st.dropShadowDistance);
+      if (st.dropShadow != null) content.style.dropShadow = !!st.dropShadow;
+      if (st.dropShadowColor) content.style.dropShadowColor = st.dropShadowColor;
+      if (st.dropShadowBlur != null) content.style.dropShadowBlur = parseInt(String(st.dropShadowBlur));
+      if (st.dropShadowAngle != null) content.style.dropShadowAngle = Number(st.dropShadowAngle);
+      if (st.dropShadowDistance != null) content.style.dropShadowDistance = Number(st.dropShadowDistance);
     }
-    // Apply generic style.zIndex even for non-text nodes
-    if (updates.style) {
-      const st: any = updates.style;
-      if (st.zIndex != null) {
-        try { (node as any).zIndex = Number(st.zIndex); (node as any).parent?.sortChildren?.(); } catch {}
-      }
-    }
-    // Update rich text base style if applicable
-    if (updates.style && (node as any).__isRichText) {
+
+    if (updates.style && (content as any).__isRichText) {
       try {
-        const base = (node as any).__richBaseStyle || {};
+        const base = (content as any).__richBaseStyle || {};
         const next = { ...base };
         const st: any = updates.style;
-        if (st.fill || st.color) next.fill = (st.fill || st.color);
+        if (st.fill || st.color) next.fill = st.fill || st.color;
         if (st.fontSize) next.fontSize = parseInt(String(st.fontSize));
         if (st.textAlign || st.align) next.align = st.textAlign || st.align;
         if (st.lineHeight) next.lineHeight = parseInt(String(st.lineHeight));
@@ -422,64 +463,66 @@ export class PixiRendererManager implements IRendererManager {
         if (st.dropShadowBlur != null) next.dropShadowBlur = parseInt(String(st.dropShadowBlur));
         if (st.dropShadowAngle != null) next.dropShadowAngle = Number(st.dropShadowAngle);
         if (st.dropShadowDistance != null) next.dropShadowDistance = Number(st.dropShadowDistance);
-        (node as any).__richBaseStyle = next;
-        // re-render with current raw text
-        const raw = (node as any).__rawText;
+        (content as any).__richBaseStyle = next;
+        const raw = (content as any).__rawText;
         if (raw != null) {
           this.updateElement(id, { type: 'text', content: raw } as any);
+          return;
         }
       } catch {}
     }
-    // note: anchor updates handled before position
+
+    node.update(0);
   }
 
   removeElement(id: string): void {
     const node = this.elements.get(id);
     if (!node) return;
-    // If removing current exclusive node, clear guard
+    const wrapper: any = node.wrapper;
     if (this.exclusiveInteractiveId === id) {
       try { this.clearExclusiveInteractive(id); } catch {}
     }
-    try { this.app.stage.removeChild(node); node.destroy?.({ children: true, texture: false, baseTexture: false }); } catch {}
+    try {
+      if (wrapper?.parent) wrapper.parent.removeChild(wrapper);
+      node.attachTo(null);
+    } catch {}
+    try { node.destroy(); } catch {}
     this.elements.delete(id);
   }
-
   render(): void {
     // Pixi auto-renders each frame via ticker. No-op.
   }
 
   // Pixi-specific helpers for handlers
   getNode(id: string): any | undefined {
-    return this.elements.get(id);
+    return this.elements.get(id)?.wrapper;
   }
   // Alias for generic handlers
   getElement(id: string): any | undefined { return this.getNode(id); }
 
   // Clear stage and internal registries when switching levels/scenes
+
   clearAll(): void {
     try {
-      // remove and destroy all created nodes
       for (const [id, node] of this.elements.entries()) {
-        // Detach any per-node ticker watchers (e.g., CHECK_IN_AREA)
+        const wrapper: any = node.wrapper;
         try {
-          const watchers = (node as any).__checkAreaWatchers as Map<string, any> | undefined;
+          const watchers = (wrapper as any).__checkAreaWatchers as Map<string, any> | undefined;
           if (watchers && this.app?.ticker) {
             watchers.forEach((w: any) => { try { this.app.ticker.remove(w.fn); } catch {} });
           }
         } catch {}
-        // Remove window-level drag listeners if present
         try {
-          const dh = (node as any).__dragHandlers;
+          const dh = (wrapper as any).__dragHandlers;
           if (dh?.winUp) { window.removeEventListener('pointerup', dh.winUp as any); }
         } catch {}
-        try { this.app.stage.removeChild(node); } catch {}
-        try { node.destroy?.({ children: true, texture: false, baseTexture: false }); } catch {}
+        try { wrapper.parent?.removeChild(wrapper); } catch {}
+        try { node.destroy(); } catch {}
       }
     } catch {}
     try { this.app.stage.removeChildren(); } catch {}
     this.elements.clear();
     this.dropZones.clear();
-    // Remove stage-level pointer listeners possibly registered by drag handlers
     try {
       const st: any = this.getStage?.();
       st?.removeAllListeners?.('pointermove');
@@ -487,7 +530,6 @@ export class PixiRendererManager implements IRendererManager {
       st?.removeAllListeners?.('pointerupoutside');
     } catch {}
     try { (this.app?.renderer as any)?.textureGC?.run?.(); } catch {}
-    // Best-effort: clear texture caches to avoid accumulating blob textures across level switches
     try {
       const utils: any = this.pixi?.utils;
       const BT = utils?.BaseTextureCache || {};
@@ -496,7 +538,6 @@ export class PixiRendererManager implements IRendererManager {
       for (const k in TC) { try { TC[k]?.destroy?.(true); } catch {} delete (TC as any)[k]; }
     } catch {}
   }
-
   // Expose Pixi app/stage for custom effects
   getApp(): any { return this.app; }
   getStage(): any { return this.app?.stage; }
@@ -519,19 +560,20 @@ export class PixiRendererManager implements IRendererManager {
     // disable all others, preserve their states
     for (const [eid, node] of this.elements.entries()) {
       if (eid === id) continue;
+      const wrapper: any = node.wrapper;
       try {
         if (!this.savedInteraction.has(eid)) {
           this.savedInteraction.set(eid, {
-            mode: (node as any).eventMode,
-            interactive: (node as any).interactive,
-            interactiveChildren: (node as any).interactiveChildren,
-            hitArea: (node as any).hitArea
+            mode: wrapper?.eventMode,
+            interactive: wrapper?.interactive,
+            interactiveChildren: wrapper?.interactiveChildren,
+            hitArea: wrapper?.hitArea
           });
         }
-        if ('eventMode' in (node as any)) (node as any).eventMode = 'none';
-        if ('interactive' in (node as any)) (node as any).interactive = false;
-        if ('interactiveChildren' in (node as any)) (node as any).interactiveChildren = false;
-        if ('hitArea' in (node as any)) (node as any).hitArea = null;
+        if (wrapper && 'eventMode' in wrapper) wrapper.eventMode = 'none';
+        if (wrapper && 'interactive' in wrapper) wrapper.interactive = false;
+        if (wrapper && 'interactiveChildren' in wrapper) wrapper.interactiveChildren = false;
+        if (wrapper && 'hitArea' in wrapper) wrapper.hitArea = null;
       } catch {}
     }
   }
@@ -544,11 +586,12 @@ export class PixiRendererManager implements IRendererManager {
     for (const [eid, saved] of this.savedInteraction.entries()) {
       const node = this.elements.get(eid);
       if (!node) { this.savedInteraction.delete(eid); continue; }
+      const wrapper: any = node.wrapper;
       try {
-        if ('eventMode' in (node as any)) (node as any).eventMode = saved.mode ?? (node as any).eventMode;
-        if ('interactive' in (node as any)) (node as any).interactive = (saved.interactive ?? (node as any).interactive);
-        if ('interactiveChildren' in (node as any)) (node as any).interactiveChildren = (saved.interactiveChildren ?? (node as any).interactiveChildren);
-        if ('hitArea' in (node as any)) (node as any).hitArea = (saved.hitArea ?? (node as any).hitArea);
+        if (wrapper && 'eventMode' in wrapper) wrapper.eventMode = saved.mode ?? wrapper.eventMode;
+        if (wrapper && 'interactive' in wrapper) wrapper.interactive = saved.interactive ?? wrapper.interactive;
+        if (wrapper && 'interactiveChildren' in wrapper) wrapper.interactiveChildren = saved.interactiveChildren ?? wrapper.interactiveChildren;
+        if (wrapper && 'hitArea' in wrapper) wrapper.hitArea = saved.hitArea ?? wrapper.hitArea;
       } catch {}
     }
     this.savedInteraction.clear();

--- a/src/browser/PixiSetDraggableHandler.ts
+++ b/src/browser/PixiSetDraggableHandler.ts
@@ -16,6 +16,7 @@ export class PixiSetDraggableHandler extends BaseCommandHandler {
     const state = (context as any).stateManager;
     const node = rm?.getNode ? rm.getNode(id) : undefined;
     if (!node) return this.createErrorResult(`Element not found: ${id}`);
+    const elementNode: any = (node as any).__elementNode;
 
     // Clear previous handlers
     if (node.__dragHandlers) {
@@ -61,12 +62,18 @@ export class PixiSetDraggableHandler extends BaseCommandHandler {
       try { if (typeof (node as any).__animToken !== 'number') (node as any).__animToken = 0; (node as any).__animToken++; } catch {}
       dragging = true; node.cursor = 'grabbing'; (node as any).__dragging = true;
       const pos = e.data.getLocalPosition(node.parent);
-      offset.x = pos.x - node.x; offset.y = pos.y - node.y;
-      context.eventManager.emit('drag_start', { elementId: id, startPosition: { x: node.x, y: node.y }, timestamp: Date.now() });
+      const basePos = elementNode?.getBaseSnapshot?.();
+      const currentX = basePos?.x ?? node.x;
+      const currentY = basePos?.y ?? node.y;
+      offset.x = pos.x - currentX; offset.y = pos.y - currentY;
+      context.eventManager.emit('drag_start', { elementId: id, startPosition: { x: currentX, y: currentY }, timestamp: Date.now() });
     };
     const up = () => {
       if (!dragging) return; dragging = false; node.cursor = 'grab'; (node as any).__dragging = false;
-      context.eventManager.emit('drag_end', { elementId: id, endPosition: { x: node.x, y: node.y }, timestamp: Date.now() });
+      const basePos = elementNode?.getBaseSnapshot?.();
+      const endX = basePos?.x ?? node.x;
+      const endY = basePos?.y ?? node.y;
+      context.eventManager.emit('drag_end', { elementId: id, endPosition: { x: endX, y: endY }, timestamp: Date.now() });
       // Robust hit test: use global bounds rectangle intersection
       const zones = rm.getDropZones ? rm.getDropZones() : [];
       const b = node.getBounds();
@@ -95,7 +102,19 @@ export class PixiSetDraggableHandler extends BaseCommandHandler {
       }
     };
     const upOutside = () => { dragging = false; node.cursor = 'grab'; (node as any).__dragging = false; };
-    const move = (e: any) => { if (!dragging) return; const pos = e.data.getLocalPosition(node.parent); node.x = pos.x - offset.x; node.y = pos.y - offset.y; };
+    const move = (e: any) => {
+      if (!dragging) return;
+      const pos = e.data.getLocalPosition(node.parent);
+      const nx = pos.x - offset.x;
+      const ny = pos.y - offset.y;
+      if (elementNode?.setBasePosition) {
+        elementNode.setBasePosition(nx, ny);
+        elementNode.update(0);
+      } else {
+        node.x = nx;
+        node.y = ny;
+      }
+    };
     // Global handlers bound to stage so drag doesn't break when pointer leaves the sprite
     const stage = rm.getStage?.();
     const stageMove = (e: any) => move(e);

--- a/src/browser/rendering/RenderElementNode.ts
+++ b/src/browser/rendering/RenderElementNode.ts
@@ -1,0 +1,897 @@
+import { Easings } from '../anim/Easings';
+
+type NullableNumber = number | null | undefined;
+
+export interface RenderedTransform {
+  x: number;
+  y: number;
+  scaleX: number;
+  scaleY: number;
+  rotation: number;
+  alpha: number;
+  width: number;
+  height: number;
+}
+
+interface BaseTransform {
+  x: number;
+  y: number;
+  scaleX: number;
+  scaleY: number;
+  rotation: number;
+  alpha: number;
+  visible: boolean;
+}
+
+interface AnimationState {
+  x: number;
+  y: number;
+  scaleX: number;
+  scaleY: number;
+  rotation: number;
+  alpha: number;
+}
+
+interface KeyframeState {
+  time: number;
+  state: Partial<AnimationState> & { alpha?: number };
+  easing: keyof typeof Easings;
+}
+
+interface TimelineData {
+  keyframes: KeyframeState[];
+  duration: number;
+  loop: boolean;
+}
+
+const DEFAULT_BASE: BaseTransform = {
+  x: 0,
+  y: 0,
+  scaleX: 1,
+  scaleY: 1,
+  rotation: 0,
+  alpha: 1,
+  visible: true,
+};
+
+const DEFAULT_ANIM: AnimationState = {
+  x: 0,
+  y: 0,
+  scaleX: 1,
+  scaleY: 1,
+  rotation: 0,
+  alpha: 1,
+};
+
+const clamp = (v: number, min = -Number.MAX_VALUE, max = Number.MAX_VALUE) => Math.max(min, Math.min(max, v));
+
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+
+const resolveScaleValue = (v: any): { x: number; y: number } | undefined => {
+  if (v == null) return undefined;
+  if (typeof v === 'number') return { x: v, y: v };
+  if (typeof v === 'object') {
+    const sx = v.x != null ? Number(v.x) : v.width != null ? Number(v.width) : undefined;
+    const sy = v.y != null ? Number(v.y) : v.height != null ? Number(v.height) : undefined;
+    return {
+      x: sx != null && Number.isFinite(sx) ? sx : 1,
+      y: sy != null && Number.isFinite(sy) ? sy : 1,
+    };
+  }
+  return undefined;
+};
+
+let nextNodeId = 1;
+
+export class RenderElementNode {
+  public readonly id: string;
+  public readonly type: string;
+  public readonly wrapper: any;
+  public readonly animLayer: any;
+  public readonly content: any;
+  public parent: RenderElementNode | null = null;
+  public children: Set<RenderElementNode> = new Set();
+  private base: BaseTransform = { ...DEFAULT_BASE };
+  private animation: AnimationState = { ...DEFAULT_ANIM };
+  private rendered: RenderedTransform = {
+    x: 0,
+    y: 0,
+    scaleX: 1,
+    scaleY: 1,
+    rotation: 0,
+    alpha: 1,
+    width: 0,
+    height: 0,
+  };
+  private pixi: any;
+  private sizeLocked = false;
+  private width = 0;
+  private height = 0;
+  private anchorX = 0;
+  private anchorY = 0;
+  private anchorCenter = false;
+  private destroyed = false;
+  private dirty = true;
+  private currentTimeline: TimelineData | null = null;
+  private timelineElapsed = 0;
+  private pendingLoop: TimelineData | null = null;
+  private loopTimeline: TimelineData | null = null;
+  private loopElapsed = 0;
+  private playingLoop = false;
+  private awaitingEntry = false;
+  private timelineRequest = 0;
+  private easingCache = new Map<string, (t: number) => number>();
+  private fetchTimeline: ((specId: string) => Promise<any | null>) | null = null;
+  private fetchContext: any = null;
+  private wrapperSetX?: (value: number) => void;
+  private wrapperSetY?: (value: number) => void;
+  private wrapperSetRotation?: (value: number) => void;
+  private wrapperSetAngle?: (value: number) => void;
+  private wrapperSetAlpha?: (value: number) => void;
+  private wrapperSetVisible?: (value: boolean) => void;
+  private wrapperPositionRef: any;
+  private wrapperPositionSet?: (x: number, y: number) => void;
+  private wrapperScaleRef: any;
+  private wrapperScaleSet?: (x: number, y: number) => void;
+
+  constructor(pixi: any, type: string, visual: any, options?: { id?: string }) {
+    this.pixi = pixi;
+    this.type = type;
+    this.id = options?.id || `render-node-${nextNodeId++}`;
+
+    const Container = pixi.Container || (pixi as any).container?.Container;
+    this.wrapper = new Container();
+    this.wrapper.__elementNode = this;
+    this.wrapper.sortableChildren = true;
+    this.wrapper.name = this.id;
+
+    this.animLayer = new Container();
+    this.animLayer.name = `${this.id}_anim`;
+    this.wrapper.addChild(this.animLayer);
+
+    this.content = visual;
+    if (visual) {
+      this.animLayer.addChild(visual);
+    }
+
+    this.setupForwarding();
+  }
+
+  private setupForwarding() {
+    const node = this.wrapper as any;
+    const content = this.content as any;
+    node.__animLayer = this.animLayer;
+    node.__animTarget = this.animLayer;
+    node.__content = content;
+    node.__elementNode = this;
+
+    if (content && content.anchor) {
+      Object.defineProperty(node, 'anchor', {
+        configurable: true,
+        enumerable: true,
+        get: () => content.anchor,
+        set: (val: any) => {
+          if (!content.anchor) return;
+          try {
+            if (typeof val === 'number') content.anchor.set(val);
+            else if (val && typeof val === 'object') content.anchor.set(val.x ?? content.anchor.x, val.y ?? content.anchor.y);
+          } catch {}
+        },
+      });
+    }
+
+    const findDescriptor = (target: any, prop: string): PropertyDescriptor | undefined => {
+      let cur = target;
+      while (cur) {
+        const desc = Object.getOwnPropertyDescriptor(cur, prop);
+        if (desc) return desc;
+        cur = Object.getPrototypeOf(cur);
+      }
+      return undefined;
+    };
+
+    const bindSetter = <T extends (...args: any[]) => any>(desc?: PropertyDescriptor, fallback?: T): T | undefined => {
+      if (desc && typeof desc.set === 'function') {
+        return desc.set as T;
+      }
+      return fallback;
+    };
+
+    const wrapperProto = Object.getPrototypeOf(node);
+    this.wrapperSetX = bindSetter(findDescriptor(wrapperProto, 'x'));
+    this.wrapperSetY = bindSetter(findDescriptor(wrapperProto, 'y'));
+    this.wrapperSetRotation = bindSetter(findDescriptor(wrapperProto, 'rotation'));
+    this.wrapperSetAngle = bindSetter(findDescriptor(wrapperProto, 'angle'));
+    this.wrapperSetAlpha = bindSetter(findDescriptor(wrapperProto, 'alpha'));
+    this.wrapperSetVisible = bindSetter(findDescriptor(wrapperProto, 'visible'));
+
+    const positionDesc = findDescriptor(wrapperProto, 'position');
+    this.wrapperPositionRef = positionDesc?.get ? positionDesc.get.call(node) : node.position;
+    if (this.wrapperPositionRef && typeof this.wrapperPositionRef.set === 'function') {
+      this.wrapperPositionSet = this.wrapperPositionRef.set.bind(this.wrapperPositionRef);
+    }
+
+    const scaleDesc = findDescriptor(wrapperProto, 'scale');
+    this.wrapperScaleRef = scaleDesc?.get ? scaleDesc.get.call(node) : node.scale;
+    if (this.wrapperScaleRef && typeof this.wrapperScaleRef.set === 'function') {
+      this.wrapperScaleSet = this.wrapperScaleRef.set.bind(this.wrapperScaleRef);
+    }
+
+    const self = this;
+
+    const applyBasePosition = (x: number | undefined, y: number | undefined) => {
+      if (x != null && Number.isFinite(x)) {
+        if (typeof self.wrapperSetX === 'function') self.wrapperSetX.call(node, x);
+        else if (self.wrapperPositionSet) self.wrapperPositionSet(x, self.wrapperPositionRef?.y ?? self.base.y);
+        else if (self.wrapperPositionRef) self.wrapperPositionRef.x = x;
+      }
+      if (y != null && Number.isFinite(y)) {
+        if (typeof self.wrapperSetY === 'function') self.wrapperSetY.call(node, y);
+        else if (self.wrapperPositionSet) self.wrapperPositionSet(self.wrapperPositionRef?.x ?? self.base.x, y);
+        else if (self.wrapperPositionRef) self.wrapperPositionRef.y = y;
+      }
+    };
+
+    const applyBaseScale = (sx: number | undefined, sy: number | undefined) => {
+      if (self.wrapperScaleRef) {
+        const nextX = sx != null && Number.isFinite(sx) ? sx : self.wrapperScaleRef.x;
+        const nextY = sy != null && Number.isFinite(sy) ? sy : self.wrapperScaleRef.y;
+        if (self.wrapperScaleSet) self.wrapperScaleSet(nextX, nextY);
+        else {
+          if (sx != null && Number.isFinite(sx)) self.wrapperScaleRef.x = sx;
+          if (sy != null && Number.isFinite(sy)) self.wrapperScaleRef.y = sy;
+        }
+      }
+    };
+
+    Object.defineProperty(node, 'x', {
+      configurable: true,
+      enumerable: true,
+      get: () => this.base.x,
+      set: (val: any) => {
+        if (val == null) return;
+        const num = Number(val);
+        if (!Number.isFinite(num)) return;
+        self.base.x = num;
+        applyBasePosition(num, undefined);
+        self.markDirty();
+      },
+    });
+
+    Object.defineProperty(node, 'y', {
+      configurable: true,
+      enumerable: true,
+      get: () => this.base.y,
+      set: (val: any) => {
+        if (val == null) return;
+        const num = Number(val);
+        if (!Number.isFinite(num)) return;
+        self.base.y = num;
+        applyBasePosition(undefined, num);
+        self.markDirty();
+      },
+    });
+
+    const positionProxy: any = {
+      get x() { return node.x; },
+      set x(v: any) { node.x = v; },
+      get y() { return node.y; },
+      set y(v: any) { node.y = v; },
+      set: (xVal: any, yVal: any) => {
+        const nx = Number(xVal);
+        const ny = Number(yVal);
+        if (Number.isFinite(nx)) node.x = nx;
+        if (Number.isFinite(ny)) node.y = ny;
+        return positionProxy;
+      },
+      copyFrom: (pt: any) => {
+        if (!pt) return positionProxy;
+        if (pt.x != null) node.x = pt.x;
+        if (pt.y != null) node.y = pt.y;
+        return positionProxy;
+      },
+    };
+
+    Object.defineProperty(node, 'position', {
+      configurable: true,
+      enumerable: true,
+      get: () => positionProxy,
+      set: (val: any) => {
+        if (!val) return;
+        if (val.x != null) node.x = val.x;
+        if (val.y != null) node.y = val.y;
+      },
+    });
+
+    Object.defineProperty(node, 'rotation', {
+      configurable: true,
+      enumerable: true,
+      get: () => self.base.rotation,
+      set: (val: any) => {
+        if (val == null) return;
+        const num = Number(val);
+        if (!Number.isFinite(num)) return;
+        self.base.rotation = num;
+        if (typeof self.wrapperSetRotation === 'function') self.wrapperSetRotation.call(node, num);
+        else if (node.transform) node.transform.rotation = num;
+        self.markDirty();
+      },
+    });
+
+    Object.defineProperty(node, 'angle', {
+      configurable: true,
+      enumerable: true,
+      get: () => self.base.rotation * 180 / Math.PI,
+      set: (val: any) => {
+        if (val == null) return;
+        const num = Number(val);
+        if (!Number.isFinite(num)) return;
+        const rad = num * Math.PI / 180;
+        self.base.rotation = rad;
+        if (typeof self.wrapperSetAngle === 'function') self.wrapperSetAngle.call(node, num);
+        else if (typeof self.wrapperSetRotation === 'function') self.wrapperSetRotation.call(node, rad);
+        else if (node.transform) node.transform.rotation = rad;
+        self.markDirty();
+      },
+    });
+
+    Object.defineProperty(node, 'alpha', {
+      configurable: true,
+      enumerable: true,
+      get: () => self.base.alpha,
+      set: (val: any) => {
+        if (val == null) return;
+        const num = Number(val);
+        if (!Number.isFinite(num)) return;
+        self.base.alpha = num;
+        if (typeof self.wrapperSetAlpha === 'function') self.wrapperSetAlpha.call(node, num);
+        else node._alpha = num;
+        self.markDirty();
+      },
+    });
+
+    Object.defineProperty(node, 'visible', {
+      configurable: true,
+      enumerable: true,
+      get: () => self.base.visible,
+      set: (val: any) => {
+        const bool = !!val;
+        self.base.visible = bool;
+        if (typeof self.wrapperSetVisible === 'function') self.wrapperSetVisible.call(node, bool);
+        else node._visible = bool;
+        self.markDirty();
+      },
+    });
+
+    const scaleProxy: any = {
+      get x() { return self.base.scaleX; },
+      set x(v: any) {
+        const num = Number(v);
+        if (!Number.isFinite(num)) return;
+        self.base.scaleX = num;
+        applyBaseScale(num, undefined);
+        self.markDirty();
+      },
+      get y() { return self.base.scaleY; },
+      set y(v: any) {
+        const num = Number(v);
+        if (!Number.isFinite(num)) return;
+        self.base.scaleY = num;
+        applyBaseScale(undefined, num);
+        self.markDirty();
+      },
+      set: (sx: any, sy?: any) => {
+        const nx = Number(sx);
+        const ny = sy == null ? nx : Number(sy);
+        if (Number.isFinite(nx)) {
+          self.base.scaleX = nx;
+        }
+        if (Number.isFinite(ny)) {
+          self.base.scaleY = ny;
+        }
+        applyBaseScale(Number.isFinite(nx) ? nx : undefined, Number.isFinite(ny) ? ny : undefined);
+        self.markDirty();
+        return scaleProxy;
+      },
+      copyFrom: (pt: any) => {
+        if (!pt) return scaleProxy;
+        if (pt.x != null) scaleProxy.x = pt.x;
+        if (pt.y != null) scaleProxy.y = pt.y;
+        return scaleProxy;
+      },
+      clone: () => ({ x: scaleProxy.x, y: scaleProxy.y }),
+    };
+
+    Object.defineProperty(node, 'scale', {
+      configurable: true,
+      enumerable: true,
+      get: () => scaleProxy,
+      set: (val: any) => {
+        if (val == null) return;
+        if (typeof val === 'number') {
+          scaleProxy.set(val, val);
+          return;
+        }
+        if (typeof val === 'object') {
+          if (val.x != null) scaleProxy.x = val.x;
+          if (val.y != null) scaleProxy.y = val.y;
+          return;
+        }
+      },
+    });
+
+    Object.defineProperty(node, 'width', {
+      configurable: true,
+      enumerable: true,
+      get: () => {
+        if (content && content.width != null) return content.width;
+        return this.width;
+      },
+      set: (val: any) => {
+        const num = Number(val);
+        if (content && content.width != null && Number.isFinite(num) && num >= 0) {
+          content.width = num;
+          this.width = num;
+          this.sizeLocked = true;
+          this.markDirty();
+        }
+      },
+    });
+
+    Object.defineProperty(node, 'height', {
+      configurable: true,
+      enumerable: true,
+      get: () => {
+        if (content && content.height != null) return content.height;
+        return this.height;
+      },
+      set: (val: any) => {
+        const num = Number(val);
+        if (content && content.height != null && Number.isFinite(num) && num >= 0) {
+          content.height = num;
+          this.height = num;
+          this.sizeLocked = true;
+          this.markDirty();
+        }
+      },
+    });
+
+    node.getRenderedTransform = () => this.getRenderedTransform();
+    node.getRenderedX = () => this.getRenderedTransform().x;
+    node.getRenderedY = () => this.getRenderedTransform().y;
+    node.getRenderedScale = () => ({ x: this.getRenderedTransform().scaleX, y: this.getRenderedTransform().scaleY });
+    node.getRenderedRotation = () => this.getRenderedTransform().rotation;
+    node.getRenderedAlpha = () => this.getRenderedTransform().alpha;
+    node.getBaseTransform = () => ({ ...this.base });
+    node.getAnimationTransform = () => ({ ...this.animation });
+  }
+
+  setFetchResolver(resolver: (specId: string) => Promise<any | null>, context: any) {
+    this.fetchTimeline = resolver;
+    this.fetchContext = context;
+  }
+
+  setBasePosition(x?: NullableNumber, y?: NullableNumber) {
+    if (x != null && Number.isFinite(Number(x))) this.base.x = Number(x);
+    if (y != null && Number.isFinite(Number(y))) this.base.y = Number(y);
+    this.markDirty();
+  }
+
+  setBaseScale(scale?: { x?: NullableNumber; y?: NullableNumber }) {
+    if (!scale) return;
+    if (scale.x != null && Number.isFinite(Number(scale.x))) this.base.scaleX = Number(scale.x);
+    if (scale.y != null && Number.isFinite(Number(scale.y))) this.base.scaleY = Number(scale.y);
+    this.markDirty();
+  }
+
+  setBaseRotation(rotation?: NullableNumber) {
+    if (rotation == null) return;
+    this.base.rotation = Number(rotation);
+    this.markDirty();
+  }
+
+  setBaseAlpha(alpha?: NullableNumber) {
+    if (alpha == null) return;
+    this.base.alpha = Number(alpha);
+    this.markDirty();
+  }
+
+  setVisible(v: boolean | undefined) {
+    if (typeof v !== 'boolean') return;
+    this.base.visible = v;
+    this.markDirty();
+  }
+
+  setSize(width?: NullableNumber, height?: NullableNumber) {
+    let changed = false;
+    if (width != null && Number.isFinite(Number(width)) && Number(width) >= 0) {
+      this.width = Number(width);
+      if (this.content && this.content.width != null) {
+        this.content.width = this.width;
+      }
+      changed = true;
+    }
+    if (height != null && Number.isFinite(Number(height)) && Number(height) >= 0) {
+      this.height = Number(height);
+      if (this.content && this.content.height != null) {
+        this.content.height = this.height;
+      }
+      changed = true;
+    }
+    if (changed) {
+      this.sizeLocked = true;
+      this.markDirty();
+    }
+  }
+
+  setAnchor(ax?: NullableNumber, ay?: NullableNumber, center?: boolean) {
+    if (center === true) this.anchorCenter = true;
+    if (ax != null) this.anchorX = Number(ax);
+    if (ay != null) this.anchorY = Number(ay);
+    if (this.content && this.content.anchor) {
+      try {
+        if (this.anchorCenter) this.content.anchor.set(0.5, 0.5);
+        else this.content.anchor.set(this.anchorX ?? this.content.anchor.x ?? 0, this.anchorY ?? this.content.anchor.y ?? 0);
+      } catch {}
+    }
+    this.markDirty();
+  }
+
+  setSizeLocked(lock: boolean) {
+    this.sizeLocked = lock;
+  }
+
+  isSizeLocked(): boolean {
+    return this.sizeLocked;
+  }
+
+  resetAnimation() {
+    this.animation = { ...DEFAULT_ANIM };
+    this.markDirty();
+  }
+
+  setAnimationState(next: Partial<AnimationState>) {
+    if (next.x != null && Number.isFinite(Number(next.x))) this.animation.x = Number(next.x);
+    if (next.y != null && Number.isFinite(Number(next.y))) this.animation.y = Number(next.y);
+    if (next.scaleX != null && Number.isFinite(Number(next.scaleX))) this.animation.scaleX = Number(next.scaleX);
+    if (next.scaleY != null && Number.isFinite(Number(next.scaleY))) this.animation.scaleY = Number(next.scaleY);
+    if (next.rotation != null && Number.isFinite(Number(next.rotation))) this.animation.rotation = Number(next.rotation);
+    if (next.alpha != null && Number.isFinite(Number(next.alpha))) this.animation.alpha = Number(next.alpha);
+    this.markDirty();
+  }
+
+  attachTo(parent: RenderElementNode | null) {
+    if (this.parent === parent) return;
+    if (this.parent) {
+      try { this.parent.animLayer.removeChild(this.wrapper); } catch {}
+      this.parent.children.delete(this);
+    }
+    this.parent = parent;
+    if (parent) {
+      parent.children.add(this);
+      try { parent.animLayer.addChild(this.wrapper); } catch {}
+    }
+    this.markDirty();
+  }
+
+  destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    if (this.parent) {
+      try { this.parent.children.delete(this); } catch {}
+    }
+    try { this.wrapper.removeChildren(); } catch {}
+    try { this.animLayer.removeChildren(); } catch {}
+    try { this.wrapper.destroy?.({ children: true, texture: false, baseTexture: false }); } catch {}
+  }
+
+  update(deltaMS: number) {
+    if (this.currentTimeline) {
+      this.timelineElapsed += deltaMS;
+      if (!this.playingLoop) {
+        const done = this.timelineElapsed >= this.currentTimeline.duration;
+        const frame = this.sampleTimeline(this.currentTimeline, Math.min(this.timelineElapsed, this.currentTimeline.duration));
+        this.setAnimationState(frame);
+        if (done) {
+          this.currentTimeline = null;
+          this.timelineElapsed = 0;
+          this.playingLoop = false;
+          if (this.pendingLoop) {
+            this.loopTimeline = this.pendingLoop;
+            this.pendingLoop = null;
+            this.loopElapsed = 0;
+            this.playingLoop = true;
+          } else {
+            this.resetAnimation();
+          }
+        }
+      }
+    }
+
+    if (this.loopTimeline) {
+      this.loopElapsed += deltaMS;
+      const duration = this.loopTimeline.duration;
+      if (duration <= 0) {
+        this.loopElapsed = 0;
+      }
+      const t = duration > 0 ? this.loopElapsed % duration : 0;
+      const frame = this.sampleTimeline(this.loopTimeline, t);
+      this.setAnimationState(frame);
+    }
+
+    if (this.dirty) this.applyTransforms();
+  }
+
+  private getEase(easing: keyof typeof Easings): (t: number) => number {
+    if (!easing) return Easings.easeInOutQuad;
+    if (!this.easingCache.has(easing)) {
+      const fn = Easings[easing] || Easings.easeInOutQuad;
+      this.easingCache.set(easing, fn);
+    }
+    return this.easingCache.get(easing)!;
+  }
+
+  private sampleTimeline(timeline: TimelineData, time: number): Partial<AnimationState> {
+    if (timeline.keyframes.length === 0) return {};
+    if (timeline.keyframes.length === 1) return timeline.keyframes[0].state;
+    const frames = timeline.keyframes;
+    let prev = frames[0];
+    let next = frames[frames.length - 1];
+    for (let i = 0; i < frames.length - 1; i++) {
+      const a = frames[i];
+      const b = frames[i + 1];
+      if (time >= a.time && time <= b.time) {
+        prev = a;
+        next = b;
+        break;
+      }
+      if (time > b.time) {
+        prev = b;
+      }
+    }
+    const span = Math.max(0.0001, next.time - prev.time);
+    const ease = this.getEase(next.easing || 'easeInOutQuad');
+    const k = clamp((time - prev.time) / span, 0, 1);
+    const eased = ease(k);
+    const out: Partial<AnimationState> = {};
+    const props: (keyof AnimationState)[] = ['x', 'y', 'scaleX', 'scaleY', 'rotation', 'alpha'];
+    for (const prop of props) {
+      const pv = (prev.state as any)[prop];
+      const nv = (next.state as any)[prop];
+      if (pv == null && nv == null) continue;
+      if (pv == null) {
+        out[prop] = nv;
+      } else if (nv == null) {
+        out[prop] = pv;
+      } else {
+        out[prop] = lerp(Number(pv), Number(nv), eased);
+      }
+    }
+    return out;
+  }
+
+  private markDirty() {
+    this.dirty = true;
+  }
+
+  private applyTransforms() {
+    this.dirty = false;
+    try {
+      if (typeof this.wrapperSetX === 'function') this.wrapperSetX.call(this.wrapper, this.base.x);
+      else if (this.wrapperPositionRef) this.wrapperPositionRef.x = this.base.x;
+      if (typeof this.wrapperSetY === 'function') this.wrapperSetY.call(this.wrapper, this.base.y);
+      else if (this.wrapperPositionRef) this.wrapperPositionRef.y = this.base.y;
+      if (this.wrapperScaleSet) this.wrapperScaleSet(this.base.scaleX, this.base.scaleY);
+      else if (this.wrapperScaleRef) {
+        this.wrapperScaleRef.x = this.base.scaleX;
+        this.wrapperScaleRef.y = this.base.scaleY;
+      }
+      if (typeof this.wrapperSetRotation === 'function') this.wrapperSetRotation.call(this.wrapper, this.base.rotation);
+      else if (this.wrapper.transform) this.wrapper.transform.rotation = this.base.rotation;
+      if (typeof this.wrapperSetAlpha === 'function') this.wrapperSetAlpha.call(this.wrapper, this.base.alpha);
+      else (this.wrapper as any)._alpha = this.base.alpha;
+      if (typeof this.wrapperSetVisible === 'function') this.wrapperSetVisible.call(this.wrapper, this.base.visible);
+      else (this.wrapper as any)._visible = this.base.visible;
+    } catch {}
+
+    try {
+      this.animLayer.x = this.animation.x;
+      this.animLayer.y = this.animation.y;
+      if (this.animLayer.scale) {
+        this.animLayer.scale.x = this.animation.scaleX;
+        this.animLayer.scale.y = this.animation.scaleY;
+      }
+      this.animLayer.rotation = this.animation.rotation;
+      this.animLayer.alpha = this.animation.alpha;
+    } catch {}
+
+    this.updateRenderedTransform();
+  }
+
+  private updateRenderedTransform() {
+    try {
+      const global = this.animLayer.getGlobalPosition(new this.pixi.Point());
+      const wt = this.animLayer.worldTransform;
+      const scaleX = Math.sqrt((wt.a * wt.a) + (wt.b * wt.b));
+      const scaleY = Math.sqrt((wt.c * wt.c) + (wt.d * wt.d));
+      const rotation = Math.atan2(wt.b, wt.a);
+      const alpha = this.animLayer.worldAlpha ?? (this.wrapper.worldAlpha ?? this.base.alpha);
+      const width = this.width || (this.content?.width ?? 0);
+      const height = this.height || (this.content?.height ?? 0);
+      this.rendered = {
+        x: global.x,
+        y: global.y,
+        scaleX,
+        scaleY,
+        rotation,
+        alpha,
+        width: width * scaleX,
+        height: height * scaleY,
+      };
+    } catch {
+      // ignore
+    }
+  }
+
+  getRenderedTransform(): RenderedTransform {
+    return { ...this.rendered };
+  }
+
+  getBaseSnapshot(): BaseTransform {
+    return { ...this.base };
+  }
+
+  getAnimationSnapshot(): AnimationState {
+    return { ...this.animation };
+  }
+
+  async setEntryTimeline(specId: string, options: { timeline?: any; duration?: number; resolver?: (spec: string) => Promise<any | null>; context?: any }) {
+    if (!specId) return;
+    this.timelineRequest++;
+    const req = this.timelineRequest;
+    if (options.resolver) {
+      this.setFetchResolver(options.resolver, options.context);
+    }
+    const data = options.timeline || (await this.fetchTimeline?.(specId));
+    if (!data) return;
+    if (req !== this.timelineRequest) return;
+    const timeline = this.buildTimeline(data, options.duration);
+    this.currentTimeline = timeline;
+    this.timelineElapsed = 0;
+    this.pendingLoop = null;
+    this.loopTimeline = null;
+    this.loopElapsed = 0;
+    this.playingLoop = false;
+    this.resetAnimation();
+  }
+
+  async setLoopTimeline(specId: string, options: { timeline?: any; duration?: number; resolver?: (spec: string) => Promise<any | null>; context?: any; startAfterEntry?: boolean }) {
+    if (!specId) return;
+    this.timelineRequest++;
+    const req = this.timelineRequest;
+    if (options.resolver) {
+      this.setFetchResolver(options.resolver, options.context);
+    }
+    const data = options.timeline || (await this.fetchTimeline?.(specId));
+    if (!data) return;
+    if (req !== this.timelineRequest) return;
+    const timeline = this.buildTimeline(data, options.duration, true);
+    if (options.startAfterEntry && this.currentTimeline) {
+      this.pendingLoop = timeline;
+    } else {
+      this.loopTimeline = timeline;
+      this.loopElapsed = 0;
+      this.pendingLoop = null;
+      this.playingLoop = true;
+    }
+  }
+
+  clearLoopTimeline() {
+    this.loopTimeline = null;
+    this.loopElapsed = 0;
+    this.pendingLoop = null;
+    this.playingLoop = false;
+    this.resetAnimation();
+  }
+
+  private buildTimeline(data: any, overrideDuration?: number, loop = false): TimelineData {
+    const parseMs = (v: any): number => {
+      if (v == null) return 0;
+      if (typeof v === 'number') return v;
+      const s = String(v).trim();
+      if (/^\d+(\.\d+)?s$/i.test(s)) return Math.round(parseFloat(s) * 1000);
+      if (/^\d+(\.\d+)?ms$/i.test(s)) return Math.round(parseFloat(s));
+      const n = Number(s);
+      return Number.isFinite(n) ? n : 0;
+    };
+
+    const rawTimeline = Array.isArray(data?.timeline) ? data.timeline : [];
+    const baseSnapshot = this.getBaseSnapshot();
+    const keyframes: KeyframeState[] = [];
+    const relative = data?.relative != null ? !!data.relative : this.isSizeLocked();
+    const durationOverride = overrideDuration != null ? parseMs(overrideDuration) : parseMs(data?.duration ?? data?.period ?? data?.cycle ?? (data?.seconds != null ? Number(data.seconds) * 1000 : undefined));
+
+    const safeAlpha = (v: any, fallback: number) => {
+      const num = Number(v);
+      if (!Number.isFinite(num)) return fallback;
+      return clamp(num, 0, 1);
+    };
+
+    const convertProps = (props: any): Partial<AnimationState> => {
+      const out: Partial<AnimationState> = {};
+      if (!props) return out;
+
+      const scale = resolveScaleValue(props.scale);
+      if (scale) {
+        if (out.scaleX == null) out.scaleX = scale.x;
+        if (out.scaleY == null) out.scaleY = scale.y;
+      }
+      if (props.scaleX != null) out.scaleX = Number(props.scaleX);
+      if (props.scaleY != null) out.scaleY = Number(props.scaleY);
+      if (props.x != null) out.x = Number(props.x);
+      if (props.y != null) out.y = Number(props.y);
+      if (props.alpha != null) out.alpha = Number(props.alpha);
+      if (props.rotation != null) out.rotation = Number(props.rotation);
+      if (props.angle != null) out.rotation = Number(props.angle) * Math.PI / 180;
+      return out;
+    };
+
+    for (const entry of rawTimeline) {
+      if (!entry) continue;
+      const time = parseMs(entry.time);
+      const props = convertProps(entry.props);
+      const easing: keyof typeof Easings = entry.ease || 'easeInOutQuad';
+
+      const state: Partial<AnimationState> = {};
+      if (props.x != null) {
+        const abs = relative ? baseSnapshot.x + props.x : props.x;
+        state.x = abs - baseSnapshot.x;
+      }
+      if (props.y != null) {
+        const abs = relative ? baseSnapshot.y + props.y : props.y;
+        state.y = abs - baseSnapshot.y;
+      }
+      if (props.scaleX != null) {
+        const abs = relative ? baseSnapshot.scaleX * props.scaleX : props.scaleX;
+        const denom = baseSnapshot.scaleX === 0 ? 1 : baseSnapshot.scaleX;
+        state.scaleX = abs / denom;
+      }
+      if (props.scaleY != null) {
+        const abs = relative ? baseSnapshot.scaleY * props.scaleY : props.scaleY;
+        const denom = baseSnapshot.scaleY === 0 ? 1 : baseSnapshot.scaleY;
+        state.scaleY = abs / denom;
+      }
+      if (props.rotation != null) {
+        const abs = relative ? baseSnapshot.rotation + props.rotation : props.rotation;
+        state.rotation = abs - baseSnapshot.rotation;
+      }
+      if (props.alpha != null) {
+        const abs = relative ? baseSnapshot.alpha * props.alpha : props.alpha;
+        const denom = baseSnapshot.alpha === 0 ? 1 : baseSnapshot.alpha;
+        state.alpha = abs / denom;
+      }
+
+      keyframes.push({ time, state, easing });
+    }
+
+    if (keyframes.length === 0) {
+      keyframes.push({ time: 0, state: {}, easing: 'easeInOutQuad' });
+    }
+
+    keyframes.sort((a, b) => a.time - b.time);
+
+    let duration = keyframes[keyframes.length - 1].time;
+    if (durationOverride && durationOverride > 0) {
+      const scaleFactor = duration > 0 ? durationOverride / duration : 1;
+      duration = durationOverride;
+      keyframes.forEach(k => { k.time = Math.round(k.time * scaleFactor); });
+    }
+
+    return {
+      keyframes,
+      duration,
+      loop,
+    };
+  }
+}
+

--- a/src/commands/FlipCardHandler.ts
+++ b/src/commands/FlipCardHandler.ts
@@ -14,6 +14,7 @@ export class FlipCardHandler extends BaseCommandHandler {
     const rm: any = context.renderManager as any;
     const node = rm?.getNode ? rm.getNode(elementId) : null;
     if (!node) return this.createErrorResult(`Element not found: ${elementId}`);
+    const animTarget: any = (node as any).__animLayer || node;
 
     // 解析前/后贴图 URL
     const resolveUrl = (idOrUrl?: string): string | undefined => {
@@ -49,9 +50,9 @@ export class FlipCardHandler extends BaseCommandHandler {
     }
 
     // 第一半：缩到 0
-    const from1 = { ...this.stateToAnim(node) };
-    const to1   = { scale: { x: 0.001, y: node.scale?.y ?? 1 } };
-    await animator.animate(node as any, from1, to1, half, easing);
+    const from1 = { ...this.stateToAnim(animTarget) };
+    const to1   = { scale: { x: 0.001, y: animTarget.scale?.y ?? 1 } };
+    await animator.animate(animTarget as any, from1, to1, half, easing);
 
     // 中点：切贴图
     const prevRenderable = (node as any).renderable ?? true;
@@ -60,9 +61,9 @@ export class FlipCardHandler extends BaseCommandHandler {
     await new Promise<void>(resolve => requestAnimationFrame(() => { (node as any).renderable = prevRenderable; resolve(); }));
 
     // 第二半：从 0 回到 1
-    const from2 = { ...this.stateToAnim(node) };
-    const to2   = { scale: { x: 1, y: node.scale?.y ?? 1 } };
-    await animator.animate(node as any, from2, to2, total - half, easing);
+    const from2 = { ...this.stateToAnim(animTarget) };
+    const to2   = { scale: { x: 1, y: animTarget.scale?.y ?? 1 } };
+    await animator.animate(animTarget as any, from2, to2, total - half, easing);
 
     // 记录当前面（便于下次翻回）
     (node as any).__frontSrc = frontUrl;
@@ -83,12 +84,12 @@ export class FlipCardHandler extends BaseCommandHandler {
     return this.createSuccessResult({ elementId, showBack, duration: total });
   }
 
-  private stateToAnim(node: any) {
+  private stateToAnim(target: any) {
     return {
-      alpha: node.alpha ?? 1,
-      x: node.x ?? 0,
-      y: node.y ?? 0,
-      scale: { x: node.scale?.x ?? 1, y: node.scale?.y ?? 1 }
+      alpha: target.alpha ?? 1,
+      x: target.x ?? 0,
+      y: target.y ?? 0,
+      scale: { x: target.scale?.x ?? 1, y: target.scale?.y ?? 1 }
     };
   }
 

--- a/src/commands/MoveToHandler.ts
+++ b/src/commands/MoveToHandler.ts
@@ -58,13 +58,13 @@ export class MoveToHandler extends BaseCommandHandler {
         to: { x: targetX, y: targetY },
         duration: duration || 1000, // 默认1秒
         easing: easing || 'ease-out',
-        onUpdate: (progress: number, currentPos: { x: number; y: number }) => {
-          // 更新元素位置
-          element.x = currentPos.x;
-          element.y = currentPos.y;
-          
-          // 触发渲染更新
-          renderManager.render?.();
+        onUpdate: (_progress: number, currentPos: { x: number; y: number }) => {
+          try {
+            (renderManager as any).updateElement?.(elementId, { position: { x: currentPos.x, y: currentPos.y } });
+          } catch {
+            element.x = currentPos.x;
+            element.y = currentPos.y;
+          }
         },
         onComplete: () => {
           context.logger.debug(`Move animation completed for element: ${elementId}`);

--- a/src/commands/SetSelectedHandler.ts
+++ b/src/commands/SetSelectedHandler.ts
@@ -15,6 +15,8 @@ export class SetSelectedHandler extends BaseCommandHandler {
     const rm: any = context.renderManager as any;
     const node = rm?.getNode ? rm.getNode(id) : undefined;
     if (!node) return this.createErrorResult(`Element not found: ${id}`);
+    const animTarget: any = (node as any).__animLayer || node;
+    const elementNode: any = (node as any).__elementNode;
 
     const selected = !!p.selected;
     // 记录最近变更选中状态的元素ID，便于后续指令或事件引用
@@ -59,7 +61,7 @@ export class SetSelectedHandler extends BaseCommandHandler {
              if (ratio > 0 && ratio < 1e3) s.scale?.set?.(ratio);
            }
          } catch {}
-         (node as any).addChild?.(s);
+         (animTarget as any).addChild?.(s);
          (node as any).__selectOverlay = s;
          return s;
         };
@@ -74,60 +76,26 @@ export class SetSelectedHandler extends BaseCommandHandler {
     if (selected) {
       const eff = p.effect || (node as any).__selectEffect || 'pulse';
       if (eff === 'pulse') {
-        this.animator.loopPulseScale(node, 0.95, 1.05, 900);
+        this.animator.loopPulseScale(animTarget, 0.95, 1.05, 900);
       } else if (typeof eff === 'string' && eff.trim()) {
-        // 播放资源动画时间轴（非阻塞，一次性）
-        this.playTimeline(node, eff.trim(), context).catch(() => {});
+        try { await elementNode?.setEntryTimeline?.(eff.trim(), { resolver: (spec: string) => this.loadAnimationData(spec, context) }); } catch {}
       }
     } else {
-      try { this.animator.stop(node); } catch {}
-      if ((node as any).scale) { (node as any).scale.x = 1; (node as any).scale.y = 1; }
+      try { this.animator.stop(animTarget); } catch {}
+      if ((animTarget as any).scale) { (animTarget as any).scale.x = 1; (animTarget as any).scale.y = 1; }
+      try { elementNode?.clearLoopTimeline?.(); } catch {}
     }
     return this.createSuccessResult({ elementId: id, selected });
   }
 
-  private async playTimeline(node: any, specIdOrUrl: string, context: CommandContext): Promise<void> {
+  private async loadAnimationData(specIdOrUrl: string, context: CommandContext): Promise<any | null> {
     try {
       const url = await this.resolveAnimationUrl(specIdOrUrl, context);
-      if (!url || typeof (globalThis as any).fetch !== 'function') return;
-      const startToken = ((node as any).__animToken || 0);
+      if (!url || typeof (globalThis as any).fetch !== 'function') return null;
       const res = await fetch(url);
-      const data = await res.json();
-      const timeline = (data.timeline || []).slice().sort((a: any, b: any) => (a.time || 0) - (b.time || 0));
-      const relative = !!data.relative;
-      const origin = data.origin;
-      if (origin === 'center' && (node as any).anchor) (node as any).anchor.set(0.5);
-      if (timeline.length === 0) return;
-
-      const toAbs = (props: any) => this.toAnimatorProps(props);
-      const base = { x: (node as any).x || 0, y: (node as any).y || 0, alpha: (node as any).alpha ?? 1, scaleX: (node as any).scale?.x ?? 1, scaleY: (node as any).scale?.y ?? 1 };
-      const resolveWithBase = (props: any) => {
-        const out = { ...props };
-        if (relative) {
-          if (out.x != null) out.x = (base.x ?? 0) + out.x;
-          if (out.y != null) out.y = (base.y ?? 0) + out.y;
-          if (out.scaleX != null) out.scaleX = (base.scaleX ?? 1) + out.scaleX;
-          if (out.scaleY != null) out.scaleY = (base.scaleY ?? 1) + out.scaleY;
-        }
-        return out;
-      };
-
-      if (((node as any).__animToken || 0) !== startToken) return;
-      const first = timeline[0];
-      this.applyAnimatorProps(node, toAbs(resolveWithBase(first.props || {})));
-
-      for (let i = 0; i < timeline.length - 1; i++) {
-        const cur = timeline[i];
-        const nxt = timeline[i + 1];
-        if (((node as any).__animToken || 0) !== startToken) return;
-        const from = this.getAnimatorState(node);
-        const to = toAbs(resolveWithBase(nxt.props || {}));
-        const duration = Math.max(0, (nxt.time || 0) - (cur.time || 0));
-        const easing = nxt.ease || 'easeOutQuad';
-        await this.animator.animate(node, from, to, duration, easing as any);
-        if (((node as any).__animToken || 0) !== startToken) return;
-      }
-    } catch {}
+      if (!res.ok) return null;
+      return await res.json();
+    } catch { return null; }
   }
 
   private async resolveAnimationUrl(spec: string, context: CommandContext): Promise<string | null> {
@@ -137,39 +105,4 @@ export class SetSelectedHandler extends BaseCommandHandler {
     return res?.url || (typeof spec === 'string' ? spec : null);
   }
 
-  private toAnimatorProps(props: any): any {
-    const out: any = {};
-    if (props.alpha != null) out.alpha = props.alpha;
-    if (props.x != null) out.x = props.x;
-    if (props.y != null) out.y = props.y;
-    if (props.angle != null) out.angle = props.angle;
-    if (props.rotation != null) out.rotation = props.rotation;
-    if (props.scaleX != null || props.scaleY != null) {
-      out.scale = { x: props.scaleX ?? 1, y: props.scaleY ?? 1 };
-    }
-    return out;
-  }
-
-  private applyAnimatorProps(node: any, props: any) {
-    if (!props) return;
-    if (props.alpha != null) (node as any).alpha = props.alpha;
-    if (props.x != null) (node as any).x = props.x;
-    if (props.y != null) (node as any).y = props.y;
-    if (props.angle != null) { try { (node as any).angle = props.angle; } catch {} }
-    if (props.rotation != null) { try { (node as any).rotation = props.rotation; } catch {} }
-    if (props.scale && (node as any).scale) {
-      (node as any).scale.x = props.scale.x ?? (node as any).scale.x;
-      (node as any).scale.y = props.scale.y ?? (node as any).scale.y;
-    }
-  }
-
-  private getAnimatorState(node: any) {
-    const st: any = {};
-    if ((node as any).alpha != null) st.alpha = (node as any).alpha;
-    if ((node as any).x != null) st.x = (node as any).x;
-    if ((node as any).y != null) st.y = (node as any).y;
-    try { if ((node as any).angle != null) st.angle = (node as any).angle; else if ((node as any).rotation != null) st.rotation = (node as any).rotation; } catch {}
-    if ((node as any).scale) st.scale = { x: (node as any).scale.x ?? 1, y: (node as any).scale.y ?? 1 };
-    return st;
-  }
 }

--- a/src/commands/ShowImageHandler.ts
+++ b/src/commands/ShowImageHandler.ts
@@ -1,6 +1,4 @@
 import { CommandType, GameCommand, CommandContext, CommandResult, ElementConfig } from '../types';
-import { Animator } from '../browser/Animator';
-
 // Cache parsed animation JSON by resolved URL/id to avoid repeated fetch/allocations
 const ANIM_JSON_CACHE: Map<string, any> = new Map();
 import { BaseCommandHandler } from '../core/CommandExecutor';
@@ -216,222 +214,70 @@ export class ShowImageHandler extends BaseCommandHandler {
     const rm: any = context.renderManager as any;
     const node = rm?.getNode ? rm.getNode(elementId) : null;
     if (!node) return;
-    const animator = new Animator();
+    const elementNode: any = (node as any).__elementNode;
+    if (!elementNode) return;
 
-    const playTimeline = async (specIdOrUrl: string, options?: { startFromCurrent?: boolean; overrideDuration?: number }) => {
-      try {
-        const url = await this.resolveAnimationUrl(specIdOrUrl, context);
-        if (!url || typeof (globalThis as any).fetch !== 'function') return; // Node 环境跳过
-        const startToken = ((node as any).__animToken || 0);
-        const tryFetch = async (u: string): Promise<any | null> => { try { const r = await fetch(u, { cache: 'force-cache' as any }); if (r.ok) return await r.json(); } catch {} return null; };
-        let data: any = ANIM_JSON_CACHE.get(url);
-        if (!data) { data = await tryFetch(url); if (data) ANIM_JSON_CACHE.set(url, data); }
-        if (!data) {
-          try {
-            const g: any = (typeof window !== 'undefined' ? (window as any) : (globalThis as any));
-            const base: string = g?.__ASSET_BASE__ || g?.__PROJECT_BASE__ || '';
-            if (base && typeof url === 'string' && url.startsWith(base)) {
-              const rel = url.slice(base.length).replace(/^\/+/, '');
-              if (rel.startsWith('animations/')) { data = await tryFetch('/' + rel); if (data) ANIM_JSON_CACHE.set(url, data); }
+    const entrySpec: string | undefined = anim?.entry?.animId || anim?.entry?.animationId;
+    const loopSpec: string | undefined = anim?.loop?.animId || anim?.loop?.animationId;
+    const entryDuration = anim?.entry?.duration ?? anim?.entry?.period ?? anim?.entry?.cycle ?? (anim?.entry?.seconds != null ? Number(anim.entry.seconds) * 1000 : undefined);
+    const loopDuration = anim?.loop?.duration ?? anim?.loop?.period ?? anim?.loop?.cycle ?? (anim?.loop?.seconds != null ? Number(anim.loop.seconds) * 1000 : undefined);
+    const resolver = (spec: string) => this.loadAnimationData(spec, context);
+
+    try {
+      if (entrySpec) {
+        await elementNode.setEntryTimeline(entrySpec, { duration: entryDuration, resolver });
+      }
+      if (loopSpec) {
+        await elementNode.setLoopTimeline(loopSpec, { duration: loopDuration, resolver, startAfterEntry: !!entrySpec });
+        (node as any).__loopAnimId = loopSpec;
+        (node as any).__loopCancel = () => { try { elementNode.clearLoopTimeline(); } catch {} };
+        if (!(node as any).__loopPauseHandlers && (node as any).on) {
+          const onDown = () => { try { elementNode.clearLoopTimeline(); } catch {} };
+          const onUp = () => {
+            const aid = (node as any).__loopAnimId;
+            if (aid) {
+              try { elementNode.setLoopTimeline(aid, { duration: loopDuration, resolver, startAfterEntry: false }); } catch {}
             }
-          } catch {}
+          };
+          (node as any).on('pointerdown', onDown);
+          (node as any).on('pointerup', onUp);
+          (node as any).on('pointerupoutside', onUp);
+          (node as any).__loopPauseHandlers = { onDown, onUp };
         }
-        if (!data) return;
-        // Build timeline and optionally scale to declared duration (from options or JSON)
-        const parseMs = (v: any): number => {
-          if (v == null) return 0;
-          if (typeof v === 'number') return v;
-          const s = String(v).trim();
-          if (/^\d+(\.\d+)?s$/i.test(s)) return Math.round(parseFloat(s) * 1000);
-          if (/^\d+(\.\d+)?ms$/i.test(s)) return Math.round(parseFloat(s));
-          const n = Number(s);
-          return Number.isFinite(n) ? n : 0;
-        };
-        let timeline = (data.timeline || []).map((k: any) => ({ ...k, time: parseMs(k?.time) })).sort((a: any, b: any) => parseMs(a.time) - parseMs(b.time));
+      }
+    } catch {}
+  }
+
+  private async loadAnimationData(specIdOrUrl: string, context: CommandContext): Promise<any | null> {
+    try {
+      const url = await this.resolveAnimationUrl(specIdOrUrl, context);
+      if (!url || typeof (globalThis as any).fetch !== 'function') return null;
+      if (ANIM_JSON_CACHE.has(url)) return ANIM_JSON_CACHE.get(url);
+      const tryFetch = async (u: string) => {
         try {
-          const declaredRaw: any = (options && (options as any).overrideDuration) ?? (data as any).duration ?? (data as any).period ?? (data as any).cycle ?? ((data as any).seconds != null ? Number((data as any).seconds) * 1000 : undefined);
-          const declared = parseMs(declaredRaw);
-          const lastT = parseMs((timeline[timeline.length - 1]?.time) || 0);
-          const angleLastT = (() => {
-            let t = 0; for (const k of timeline) { if (k && k.props && (k.props.angle != null || k.props.rotation != null)) t = parseMs(k.time || 0); }
-            return t;
-          })();
-          let scale: number | null = null;
-          if (declared > 0) {
-            if (angleLastT > 0 && Math.abs(angleLastT - declared) > 1) scale = declared / angleLastT;
-            else if (lastT > 0 && Math.abs(lastT - declared) > 1) scale = declared / lastT;
-          }
-          if (scale && isFinite(scale) && scale > 0) {
-            timeline = timeline.map((k: any) => ({ ...k, time: Math.max(0, Math.round(parseMs(k.time || 0) * scale!)) }));
+          const resp = await fetch(u, { cache: 'force-cache' as any });
+          if (resp.ok) {
+            const data = await resp.json();
+            ANIM_JSON_CACHE.set(url, data);
+            return data;
           }
         } catch {}
-        // 若动画未声明 relative，则在元素显式设定了大小时默认按相对模式处理，避免将 scale 置为绝对 1 破坏图片自定义尺寸
-        const sizeLocked = !!(node as any).__sizeLocked;
-        const relative = (data.relative != null) ? !!data.relative : sizeLocked;
-        const origin = data.origin;
-        // Do not mutate anchor during playback to avoid coordinate drift
-        if (timeline.length === 0) return;
-
-        // If rotation or angle animation exists, rotate around visual center without shifting position
+        return null;
+      };
+      let data = await tryFetch(url);
+      if (!data) {
         try {
-          const usesRotation = timeline.some((k: any) => k && k.props && (k.props.angle != null || k.props.rotation != null));
-          if (usesRotation && !(node as any).__centerAnchored && (node as any).anchor && (typeof (node as any).anchor.set === 'function')) {
-            const ax = Number((node as any).anchor?.x ?? 0);
-            const ay = Number((node as any).anchor?.y ?? 0);
-            // Compute current visual center from old anchor and size
-            const w = Number((node as any).width || 0);
-            const h = Number((node as any).height || 0);
-            if (!(w > 0 && h > 0)) { /* wait until size ready; try in next iteration */ return; }
-            const posX = Number((node as any).x || 0);
-            const posY = Number((node as any).y || 0);
-            const centerX = posX + (0.5 - ax) * w;
-            const centerY = posY + (0.5 - ay) * h;
-            // Set anchor to center and keep center fixed
-            (node as any).anchor.set(0.5, 0.5);
-            (node as any).x = centerX; (node as any).y = centerY;
-            (node as any).__centerAnchored = true;
+          const g: any = (typeof window !== 'undefined' ? (window as any) : (globalThis as any));
+          const base: string = g?.__ASSET_BASE__ || g?.__PROJECT_BASE__ || '';
+          if (base && typeof url === 'string' && url.startsWith(base)) {
+            const rel = url.slice(base.length).replace(/^\/+/, '');
+            if (rel.startsWith('animations/')) data = await tryFetch('/' + rel);
           }
         } catch {}
-
-        const toAbs = (props: any) => this.toAnimatorProps(props);
-        // 基线：用于相对值的参考；
-        // 位置使用“当前帧 from 状态”为基线（允许与 MOVE_TO 叠加）；
-        // 缩放使用“播放开始时的锚点缩放”作为基线（避免每帧相对而累计漂移）。
-        const snapshotState = () => ({
-          x: (node as any).x || 0,
-          y: (node as any).y || 0,
-          alpha: (node as any).alpha ?? 1,
-          scaleX: (node as any).scale?.x ?? 1,
-          scaleY: (node as any).scale?.y ?? 1,
-          angle: (node as any).angle != null ? (node as any).angle : (((node as any).rotation ?? 0) * 180 / Math.PI)
-        });
-        const loopAnchor = snapshotState();
-        const lockedAnchor = snapshotState(); // 当 sizeLocked 且 relative=false 时，以显示尺寸为锚点
-        const resolveWithBase = (props: any, _posBase: { x:number; y:number }, scaleBase: { scaleX:number; scaleY:number }) => {
-          const out = { ...props };
-          // Support shorthand `scale`
-          if (out.scale != null && (out.scaleX == null && out.scaleY == null)) {
-            const s = out.scale;
-            if (typeof s === 'number') { out.scaleX = s; out.scaleY = s; }
-            else if (s && typeof s === 'object') { if (s.x != null) out.scaleX = s.x; if (s.y != null) out.scaleY = s.y; }
-          }
-          if (relative) {
-            // 位置：基于“播放开始锚点”增量（0 表示回到锚点），避免在 0 → … → 0 的时间轴中产生停滞
-            if (out.x != null) out.x = (loopAnchor.x ?? 0) + out.x;
-            if (out.y != null) out.y = (loopAnchor.y ?? 0) + out.y;
-            // 缩放：以“播放开始锚点”作为基线的乘法相对，避免帧间累计漂移
-            if (out.scaleX != null) out.scaleX = (loopAnchor.scaleX ?? 1) * out.scaleX;
-            if (out.scaleY != null) out.scaleY = (loopAnchor.scaleY ?? 1) * out.scaleY;
-            // 角度：相对增量（度）
-            if (out.angle != null) out.angle = (loopAnchor.angle ?? 0) + out.angle;
-            if (out.rotation != null) {
-              // rotation 通常表示弧度；若使用相对，直接在当前 rotation 上累加
-              const currentRot = ((loopAnchor.angle ?? 0) * Math.PI / 180);
-              out.rotation = currentRot + out.rotation;
-            }
-          } else if (sizeLocked) {
-            // 绝对模式 + 锁尺寸：将时间轴缩放视为“基于显示尺寸”的倍率（固定锚点）
-            if (out.scaleX != null) out.scaleX = (lockedAnchor.scaleX ?? 1) * out.scaleX;
-            if (out.scaleY != null) out.scaleY = (lockedAnchor.scaleY ?? 1) * out.scaleY;
-          }
-          return out;
-        };
-
-        // 应用第一帧（相对模式下也安全：y:0 => 当前位置），并在每步前检查令牌避免拖拽期突变
-        if (((node as any).__animToken || 0) !== startToken) return;
-        const first = timeline[0];
-        const startFromCurrent = !!(options && options.startFromCurrent);
-        if (!startFromCurrent) {
-          this.applyAnimatorProps(node, toAbs(resolveWithBase(first.props || {}, { x: loopAnchor.x, y: loopAnchor.y }, { scaleX: loopAnchor.scaleX, scaleY: loopAnchor.scaleY })));
-        }
-        
-        const EPS = 1e-4;
-        const almostEq = (a: number | undefined, b: number | undefined) => (a == null || b == null) ? false : Math.abs(a - b) <= EPS;
-        for (let i = 0; i < timeline.length - 1; i++) {
-          const cur = timeline[i];
-          const nxt = timeline[i + 1];
-          if (((node as any).__animToken || 0) !== startToken) return;
-          const from = this.getAnimatorState(node);
-          const to = toAbs(resolveWithBase(nxt.props || {}, { x: from.x ?? 0, y: from.y ?? 0 }, { scaleX: loopAnchor.scaleX, scaleY: loopAnchor.scaleY }));
-          const duration = Math.max(0, (nxt.time || 0) - (cur.time || 0));
-          const easing = nxt.ease || 'easeOutQuad';
-          // Skip no-op segments: either no animatable props, or target equals current values
-          const hasAnimProp = (
-            ('alpha' in to) || ('x' in to) || ('y' in to) || ('rotation' in to) || ('angle' in to) || !!to.scale
-          );
-          const looping = !!(options && options.startFromCurrent);
-          if (!hasAnimProp) { continue; }
-          const angleNoChange = ('angle' in to) ? almostEq((from as any).angle, (to as any).angle) : true;
-          const rotNoChange = ('rotation' in to) ? almostEq((from as any).rotation, (to as any).rotation) : true;
-          const noChange = (
-            (!('alpha' in to) || almostEq(from.alpha, to.alpha)) &&
-            (!('x' in to) || almostEq(from.x, to.x)) &&
-            (!('y' in to) || almostEq(from.y, to.y)) &&
-            (!to.scale || (almostEq(from.scale?.x, to.scale?.x) && almostEq(from.scale?.y, to.scale?.y))) &&
-            angleNoChange && rotNoChange
-          );
-          if (noChange) { continue; }
-          await animator.animate(node, from, to, duration, easing as any);
-          if (((node as any).__animToken || 0) !== startToken) return;
-        }
-      } catch (e) {
-        // 静默失败，避免影响主流程
       }
-    };
-
-    // 非阻塞：入场动画不再 await，让后续指令继续执行
-    const hasEntry = !!anim.entry?.animId;
-    const hasLoop = !!anim.loop?.animId;
-
-    // helper: start loop (reused for immediate or after entry finishes)
-    const startLoop = (animId: string) => {
-      let stopped = false;
-      const run = async () => {
-        // Prevent tight loop if node already destroyed or token invalidated
-        while (!stopped) {
-          try { if (!(node as any) || (node as any).destroyed) break; } catch { break; }
-          await playTimeline(animId, { startFromCurrent: true, overrideDuration: (anim.loop && (anim.loop.duration || anim.loop.period || anim.loop.cycle || (anim.loop.seconds != null ? Number(anim.loop.seconds) * 1000 : undefined))) as any });
-          // If during timeline node got killed or token changed, break
-          try { if (!(node as any) || (node as any).destroyed) break; } catch { break; }
-        }
-      };
-      run();
-      return () => { stopped = true; };
-    };
-
-    if (hasEntry) {
-      const entryId = anim.entry.animId;
-      // 播放入场动画但不阻塞处理流程
-      const entryPromise = playTimeline(entryId, { overrideDuration: (anim.entry && (anim.entry.duration || anim.entry.period || anim.entry.cycle || (anim.entry.seconds != null ? Number(anim.entry.seconds) * 1000 : undefined))) as any });
-      // 如存在循环动画：确保循环在入场结束后再开始，避免相互打架
-      if (hasLoop) {
-        entryPromise.then(() => {
-          try {
-            (node as any).__loopAnimId = anim.loop.animId;
-            if ((node as any).__loopCancel) { try { (node as any).__loopCancel(); } catch {} (node as any).__loopCancel = null; }
-            (node as any).__loopCancel = startLoop((node as any).__loopAnimId);
-          } catch {}
-        });
-      }
-    } else if (hasLoop) {
-      (node as any).__loopAnimId = anim.loop.animId;
-      if ((node as any).__loopCancel) { try { (node as any).__loopCancel(); } catch {} (node as any).__loopCancel = null; }
-      (node as any).__loopCancel = startLoop((node as any).__loopAnimId);
-    }
-
-    // 拖拽时暂停循环动画，释放时恢复（依赖 Pixi 事件，Node 环境无影响）
-    if (hasLoop && !(node as any).__loopPauseHandlers && (node as any).on) {
-      const onDown = () => {
-        // 取消循环并使任何进行中的补间立即结束
-        if (typeof (node as any).__animToken !== 'number') (node as any).__animToken = 0;
-        (node as any).__animToken++;
-        if ((node as any).__loopCancel) { try { (node as any).__loopCancel(); } catch {} (node as any).__loopCancel = null; }
-      };
-      const onUp = () => { if (!(node as any).__loopCancel && (node as any).__loopAnimId) { (node as any).__loopCancel = startLoop((node as any).__loopAnimId); } };
-      (node as any).on('pointerdown', onDown);
-      (node as any).on('pointerup', onUp);
-      (node as any).on('pointerupoutside', onUp);
-      (node as any).__loopPauseHandlers = { onDown, onUp };
+      return data;
+    } catch {
+      return null;
     }
   }
 
@@ -468,44 +314,4 @@ export class ShowImageHandler extends BaseCommandHandler {
     } catch { return spec; }
   }
 
-  private toAnimatorProps(props: any): any {
-    const out: any = {};
-    if (props.alpha != null) out.alpha = props.alpha;
-    if (props.x != null) out.x = props.x;
-    if (props.y != null) out.y = props.y;
-    // rotation / angle
-    if (props.rotation != null) out.rotation = props.rotation; // radians
-    if (props.angle != null) out.angle = props.angle; // degrees
-    // Support scaleX/scaleY or shorthand `scale`
-    if (props.scaleX != null || props.scaleY != null) {
-      out.scale = { x: props.scaleX ?? 1, y: props.scaleY ?? 1 };
-    } else if (props.scale != null) {
-      if (typeof props.scale === 'number') out.scale = { x: props.scale, y: props.scale };
-      else if (typeof props.scale === 'object') out.scale = { x: props.scale.x ?? 1, y: props.scale.y ?? 1 };
-    }
-    return out;
-  }
-
-  private applyAnimatorProps(node: any, props: any) {
-    if (!props) return;
-    if (props.alpha != null) node.alpha = props.alpha;
-    if (props.x != null) node.x = props.x;
-    if (props.y != null) node.y = props.y;
-    if (props.scale && node.scale) {
-      node.scale.x = props.scale.x ?? node.scale.x;
-      node.scale.y = props.scale.y ?? node.scale.y;
-    }
-  }
-
-  private getAnimatorState(node: any) {
-    const st: any = {};
-    if (node.alpha != null) st.alpha = node.alpha;
-    if (node.x != null) st.x = node.x;
-    if (node.y != null) st.y = node.y;
-    if (node.scale) st.scale = { x: node.scale.x ?? 1, y: node.scale.y ?? 1 };
-    // include both representations for rotation to help no-op detection
-    try { if ((node as any).angle != null) (st as any).angle = (node as any).angle; } catch {}
-    try { if ((node as any).rotation != null) (st as any).rotation = (node as any).rotation; } catch {}
-    return st;
-  }
 }


### PR DESCRIPTION
## Summary
- introduce RenderElementNode to wrap Pixi objects with base and animation layers, timeline playback, and transform proxies
- update Pixi renderer creation/update logic to build nodes through the new wrapper and expose rendered transform helpers
- adapt animation- and selection-related handlers to drive the anim layer via RenderElementNode APIs and keep drag/move commands in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68db2d59b47c83229a2616a5ee2125a2